### PR TITLE
Dependencies: replace semver by packaging to compare versions

### DIFF
--- a/qgis_deployment_toolbelt/commands/cli_upgrade.py
+++ b/qgis_deployment_toolbelt/commands/cli_upgrade.py
@@ -20,7 +20,7 @@ from urllib.request import urlopen
 
 # 3rd party library
 import click
-import semver
+from packaging.version import Version
 
 # submodules
 from qgis_deployment_toolbelt.__about__ import __title__, __uri_repository__
@@ -139,9 +139,7 @@ def upgrade(check_only: bool, where: Path):
 
     # compare it
     latest_version = latest_release.get("tag_name")
-    if semver.VersionInfo.parse(actual_version) < semver.VersionInfo.parse(
-        latest_version
-    ):
+    if Version(actual_version) < Version(latest_version):
         if check_only:
             exit_cli_normal(
                 f"A newer version is available: {latest_version}", abort=True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,5 @@ packaging>=20,<24
 pyyaml>=5.4,<7
 py-setenv>=1.1,<1.2
 pywin32==305 ; sys_platform == 'win32'
-semver>=2.13,<2.14
 send2trash>=1.7.1
 typing-extensions>=4,<5 ; python_version < '3.11'

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -14,7 +14,7 @@
 import unittest
 
 # 3rd party
-from semver import VersionInfo
+from packaging.version import parse
 from validators import url
 
 # project
@@ -59,7 +59,7 @@ class TestAbout(unittest.TestCase):
 
     def test_version_semver(self):
         """Test if version comply with semantic versioning."""
-        self.assertTrue(VersionInfo.isvalid(__about__.__version__))
+        self.assertTrue(parse(__about__.__version__))
 
 
 # ############################################################################


### PR DESCRIPTION
https://packaging.pypa.io/ instead of https://python-semver.readthedocs.io/en/stable/