### PR TITLE
Improve upgrade subcommand by handling GitHub Token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,11 +45,11 @@ jobs:
           python -m pip install -U -r requirements/testing.txt
 
       - name: Install project as a package
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python -m pip install -e .
 
       - name: Unit tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pytest
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
           python -m pip install -U -r requirements/testing.txt
 
       - name: Install project as a package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python -m pip install -e .
 
       - name: Unit tests

--- a/qgis_deployment_toolbelt/commands/upgrade.py
+++ b/qgis_deployment_toolbelt/commands/upgrade.py
@@ -105,10 +105,10 @@ def get_latest_release(api_repo_url: str) -> dict:
     request = Request(url=request_url, headers=headers)
 
     try:
-        response = urlopen(request)
-        if response.status == 200:
-            release_info = json.loads(response.read())
-            return release_info
+        with urlopen(request) as response:
+            if response.status == 200:
+                release_info = json.loads(response.read())
+        return release_info
     except Exception as err:
         logger.error(err)
         if "rate limit exceeded" in err:
@@ -118,9 +118,6 @@ def get_latest_release(api_repo_url: str) -> dict:
                 "personal token."
             )
         return None
-    finally:
-        if response is not None:
-            response.close()
 
 
 def replace_domain(url: str, new_domain: str = "api.github.com/repos") -> str:

--- a/qgis_deployment_toolbelt/commands/upgrade.py
+++ b/qgis_deployment_toolbelt/commands/upgrade.py
@@ -95,7 +95,7 @@ def get_latest_release(api_repo_url: str) -> dict:
 
     # headers
     headers = {
-        "content-type": "application/json",
+        "content-type": "application/vnd.github+json",
         "User-Agent": f"{__title_clean__}/{actual_version}",
     }
     if getenv("GITHUB_TOKEN"):
@@ -221,19 +221,25 @@ def run(args: argparse.Namespace):
                 abort=True,
             )
     else:
-        exit_msg = (f"You already have the latest released version: {latest_version}.",)
+        exit_msg = f"You already have the latest released version: {latest_version}."
+        print(exit_msg)
         exit_cli_normal(
             message=exit_msg,
             abort=True,
         )
 
     # -- DOWNLOAD ------------------------------------------------------------
+    print(f"Downloading newer version of executable for {opersys}: {latest_version}")
 
     # select remote download URL
     if release_asset_for_os := get_download_url_for_os(latest_release.get("assets")):
         remote_url, remote_content_type = release_asset_for_os
     else:
         exit_cli_error(f"Unable to identify an appropriate download URL for {opersys}.")
+
+    # handle empty content-type
+    if remote_content_type is None:
+        remote_content_type = "application/octet-stream"
 
     # destination local file
     dest_filepath = Path(

--- a/qgis_deployment_toolbelt/commands/upgrade.py
+++ b/qgis_deployment_toolbelt/commands/upgrade.py
@@ -99,6 +99,7 @@ def get_latest_release(api_repo_url: str) -> dict:
         "User-Agent": f"{__title_clean__}/{actual_version}",
     }
     if getenv("GITHUB_TOKEN"):
+        print(f"Using authenticated request to GH API: {getenv('GITHUB_TOKEN')}")
         headers["Authorization"] = f"Bearer {getenv('GITHUB_TOKEN')}"
 
     request = Request(url=request_url, headers=headers)
@@ -117,6 +118,9 @@ def get_latest_release(api_repo_url: str) -> dict:
                 "personal token."
             )
         return None
+    finally:
+        if response is not None:
+            response.close()
 
 
 def replace_domain(url: str, new_domain: str = "api.github.com/repos") -> str:

--- a/qgis_deployment_toolbelt/commands/upgrade.py
+++ b/qgis_deployment_toolbelt/commands/upgrade.py
@@ -99,7 +99,9 @@ def get_latest_release(api_repo_url: str) -> dict:
         "User-Agent": f"{__title_clean__}/{actual_version}",
     }
     if getenv("GITHUB_TOKEN"):
-        print(f"Using authenticated request to GH API: {getenv('GITHUB_TOKEN')}")
+        logger.debug(
+            f"Using authenticated request to GH API: {getenv('GITHUB_TOKEN')[:9]}****"
+        )
         headers["Authorization"] = f"Bearer {getenv('GITHUB_TOKEN')}"
 
     request = Request(url=request_url, headers=headers)

--- a/qgis_deployment_toolbelt/utils/file_downloader.py
+++ b/qgis_deployment_toolbelt/utils/file_downloader.py
@@ -65,7 +65,7 @@ def download_remote_file_to_local(
         logger.warning(f"{local_file_path} already exists. It's about to be replaced.")
         local_file_path.unlink(missing_ok=True)
 
-    # mkae sure parents folder exist
+    # make sure parents folder exist
     local_file_path.parent.mkdir(parents=True, exist_ok=True)
 
     # headers


### PR DESCRIPTION
- handle GitHub Token if environment variable `GITHUB_TOKEN` is set to avoid API rate limit
- improve headers (user-agent and content-type)
- add test against GitHub release management