### PR TITLE
Feature: handle "local" plugins

### DIFF
--- a/docs/jobs/profiles_manager.md
+++ b/docs/jobs/profiles_manager.md
@@ -69,7 +69,7 @@ Must start with:
 
 - `file://`: for local disk or network
 - `git://` (_recomended_): for git repositories
-- `https://`: for profiles downloadable through an HTTP server
+- `https://`: for profiles stored into git repositories accessible through HTTP or profiles downloadable through an HTTP server
 
 ### sync_mode
 

--- a/docs/schemas/profile/qgis_plugin.json
+++ b/docs/schemas/profile/qgis_plugin.json
@@ -55,6 +55,15 @@
             "deprecated": true,
             "type": "string"
         },
+        "url": {
+            "description": "Direct URI (URL or local path) to download the plugin archive (.zip).",
+            "type": "string",
+            "format": "uri",
+            "examples": [
+                "https: //plugins.qgis.org/plugins/QuickOSM/version/2.2.2/download/",
+                "/home/jmo/Git/Oslandia/QGIS/stsi-plugin-qgis-geocoder-locator-filter/stsi_locator_filter.1.0.0.zip"
+            ]
+        },
         "version": {
             "description": "Plugin version to install.",
             "maxLength": 14,

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -173,6 +173,7 @@ class JobPluginsDownloader(GenericJob):
                     must_be_a_folder=False,
                     must_exists=True,
                 )
+                src_plugin_path = Path(plugin.url)
             except Exception as err:
                 logger.error(
                     f"The plugin '{plugin.name}' can't be copied from {plugin.url}. "
@@ -182,13 +183,11 @@ class JobPluginsDownloader(GenericJob):
                 continue
 
             # try to copy
-            plugin_copy_path = Path(destination_parent_folder, f"{plugin.name}.zip")
-
             try:
-                copy2(src=plugin.url, dst=destination_parent_folder)
+                copy2(src=src_plugin_path, dst=destination_parent_folder)
                 logger.info(
-                    f"Plugin {plugin.name} has been copied from {plugin.guess_copy_url} "
-                    f"to {plugin_copy_path}"
+                    f"Plugin {plugin.name} has been copied from {src_plugin_path} "
+                    f"to {destination_parent_folder / src_plugin_path.name}"
                 )
                 copied_plugins.append(plugin)
             except Exception as err:

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -98,7 +98,7 @@ class JobPluginsDownloader(GenericJob):
             )
             return
 
-        # filter plugins to download, filtering out those which are not already  present locally
+        # filter plugins to download, filtering out those which are not already present locally
         if self.options.get("force") is True:
             qdt_plugins_to_download = qdt_referenced_plugins
         else:
@@ -253,6 +253,13 @@ class JobPluginsDownloader(GenericJob):
         plugins_to_download = []
 
         for plugin in input_list:
+            # keep only if remote
+            if plugin.location != "remote":
+                logger.debug(
+                    f"Ignoring plugin '{plugin.name}' because it's not stored remotly."
+                )
+                continue
+
             # build destination path
             plugin_download_path = Path(
                 self.qdt_plugins_folder, f"{plugin.id_with_version}.zip"

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -184,11 +184,27 @@ class JobPluginsDownloader(GenericJob):
 
             # try to copy
             try:
+                dst_plugin_path = destination_parent_folder / src_plugin_path.name
                 copy2(src=src_plugin_path, dst=destination_parent_folder)
                 logger.info(
                     f"Plugin {plugin.name} has been copied from {src_plugin_path} "
-                    f"to {destination_parent_folder / src_plugin_path.name}"
+                    f"to {dst_plugin_path}"
                 )
+                check_path(
+                    input_path=dst_plugin_path,
+                    must_be_a_file=True,
+                    must_exists=True,
+                    raise_error=True,
+                )
+
+                dst_plugin_path_final = dst_plugin_path.rename(
+                    dst_plugin_path.with_name(f"{plugin.id_with_version}.zip")
+                )
+                logger.debug(
+                    f"Plugin ZIP archive has been renamed from '{dst_plugin_path}' "
+                    f"into '{dst_plugin_path_final}' to make it consistent with sync."
+                )
+
                 copied_plugins.append(plugin)
             except Exception as err:
                 logger.error(

--- a/tests/test_qplugin_object.py
+++ b/tests/test_qplugin_object.py
@@ -105,8 +105,11 @@ class TestQgisPluginObject(unittest.TestCase):
 
         # plugin as object
         plugin_obj: QgisPlugin = QgisPlugin.from_dict(plugin_dict_local)
-
         self.assertIsInstance(plugin_obj.uri_to_zip, Path)
+
+        # using a file:// prefix
+        plugin_dict_local["url"] = f"file://{self.sample_plugin_downloaded}"
+        plugin_obj: QgisPlugin = QgisPlugin.from_dict(plugin_dict_local)
 
     def test_qplugin_load_from_zip(self):
         """Test plugin object loading from a ZIP archive downloaded."""
@@ -159,6 +162,9 @@ class TestQgisPluginObject(unittest.TestCase):
         self.assertEqual(plugin_obj.name, plugin_obj_from_zip.name)
         self.assertEqual(plugin_obj.version, plugin_obj_from_zip.version)
         self.assertEqual(plugin_obj.folder_name, plugin_obj_from_zip.folder_name)
+        self.assertEqual(plugin_obj.url, sample_plugin_complex.get("url"))
+        self.assertEqual(plugin_obj.download_url, sample_plugin_complex.get("url"))
+        self.assertEqual(plugin_obj.uri_to_zip, sample_plugin_complex.get("url"))
 
     def test_qplugin_versions_comparison_semver(self):
         """Test plugin compare versions semver"""

--- a/tests/test_qplugin_object.py
+++ b/tests/test_qplugin_object.py
@@ -126,7 +126,7 @@ class TestQgisPluginObject(unittest.TestCase):
 
         # prepare local download path
         local_plugin_download = Path(
-            f"{self.sample_plugin_downloaded.parent}/{plugin_obj.installation_folder_name}/"
+            f"{self.sample_plugin_downloaded.parent.parent}/{plugin_obj.installation_folder_name}/"
             f"{plugin_obj.id_with_version}.zip"
         )
 

--- a/tests/test_qplugin_object.py
+++ b/tests/test_qplugin_object.py
@@ -35,6 +35,26 @@ class TestQgisPluginObject(unittest.TestCase):
             Path("tests/fixtures/").glob("profiles/good_*.json")
         )
 
+        # -- Download a plugin to perfom tests
+        # prepare local download path
+        cls.sample_plugin_downloaded = Path(
+            "tests/fixtures/tmp/qtribu/2733_qtribu_0-14-2.zip"
+        )
+        cls.sample_plugin_downloaded.parent.mkdir(parents=True, exist_ok=True)
+
+        # download plugin zip archive (only if it doesn't exist already)
+        if not cls.sample_plugin_downloaded.exists():
+            download_remote_file_to_local(
+                remote_url_to_download="https://github.com/geotribu/qtribu/releases/download/0.14.2/qtribu.0.14.2.zip",
+                local_file_path=cls.sample_plugin_downloaded.resolve(),
+                content_type="application/zip",
+            )
+
+        # check download worked
+        assert (
+            cls.sample_plugin_downloaded.is_file() is True
+        ), "Downloading fixture plugin failed."
+
     def test_qplugin_load_from_profile(self):
         """Test plugin object loading from profile object."""
         for p in self.good_profiles_files:
@@ -57,7 +77,7 @@ class TestQgisPluginObject(unittest.TestCase):
             "type": "remote",
         }
 
-        plugin_obj_one = QgisPlugin.from_dict(sample_plugin_complete)
+        plugin_obj_one: QgisPlugin = QgisPlugin.from_dict(sample_plugin_complete)
 
         sample_plugin_incomplete = {
             "name": "french_locator_filter",
@@ -65,9 +85,28 @@ class TestQgisPluginObject(unittest.TestCase):
             "official_repository": True,
         }
 
-        plugin_obj_two = QgisPlugin.from_dict(sample_plugin_incomplete)
+        plugin_obj_two: QgisPlugin = QgisPlugin.from_dict(sample_plugin_incomplete)
 
         self.assertEqual(plugin_obj_one, plugin_obj_two)
+        self.assertEqual(plugin_obj_one.download_url, plugin_obj_one.uri_to_zip)
+
+    def test_qplugin_load_from_dict_local(self):
+        """Test plugin object loading from dict, pointing to a local plugin."""
+        # plugin as dict
+        plugin_dict_local = {
+            "name": "QTribu",
+            "folder_name": "qtribu",
+            "official_repository": False,
+            "plugin_id": 2733,
+            "location": "local",
+            "url": self.sample_plugin_downloaded,
+            "version": "0.14.2",
+        }
+
+        # plugin as object
+        plugin_obj: QgisPlugin = QgisPlugin.from_dict(plugin_dict_local)
+
+        self.assertIsInstance(plugin_obj.uri_to_zip, Path)
 
     def test_qplugin_load_from_zip(self):
         """Test plugin object loading from a ZIP archive downloaded."""
@@ -87,7 +126,7 @@ class TestQgisPluginObject(unittest.TestCase):
 
         # prepare local download path
         local_plugin_download = Path(
-            f"tests/fixtures/tmp/{plugin_obj.installation_folder_name}/"
+            f"{self.sample_plugin_downloaded.parent}/{plugin_obj.installation_folder_name}/"
             f"{plugin_obj.id_with_version}.zip"
         )
 


### PR DESCRIPTION
Until now, only "remote" plugins were managed. This PR adds ability to copy plugins stored locally.

Typically in a `profile.json`:

```json
{
  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
  "name": "basic",
  "author": "QDT Dev Team",
  "email": "qgis@oslandia.com",
  "icon": "images/qgis.ico",
  "splash": "images/splash.png",
  "qgisMinimumVersion": "3.16",
  "qgisMaximumVersion": "3.30",
  "version": "1.0.0",
  "plugins": [
    {
      "name": "Spreadsheet Layers",
      "folder_name": "SpreadsheetLayers",
      "official_repository": true,
      "plugin_id": 766,
      "version": "2.0.0"
    },
    {
      "name": "Custom intra plugin",
      "folder_name": "intra_plugin",
      "official_repository": false,
      "plugin_id": 202303,
      "location": "local",
      "url": "S://QGIS//plugins//intra-plugin.zip"