### PR TITLE
Fix: accept different types (URLs or str) as environment variables values

### DIFF
--- a/docs/jobs/environment_variables.md
+++ b/docs/jobs/environment_variables.md
@@ -47,3 +47,14 @@ Possible_values:
 ### value
 
 Value to set to the environment variable.
+
+### value_type
+
+Value type to avoid ambiguity.
+
+Possible_values:
+
+- `bool`: a boolean (True, true, False, false, 0, 1)
+- `path`: a valid local path (user and variables expansion are supported)
+- `str`: a raw and simple string. Default value.
+- `url`: an HTTP/S URL

--- a/docs/schemas/scenario/jobs/manage-env-vars.json
+++ b/docs/schemas/scenario/jobs/manage-env-vars.json
@@ -10,10 +10,7 @@
       "action": {
         "default": "add",
         "description": "Tell the job what to do with the environment variable.",
-        "enum": [
-          "add",
-          "remove"
-        ],
+        "enum": ["add", "remove"],
         "type": "string"
       },
       "name": {
@@ -23,18 +20,17 @@
       "scope": {
         "default": "user",
         "description": "Level of the environment variable.",
-        "enum": [
-          "user",
-          "system"
-        ],
+        "enum": ["user", "system"],
         "type": "string"
       },
       "value": {
         "description": "Value to set to the environment variable.",
-        "type": [
-          "boolean",
-          "string"
-        ]
+        "type": ["boolean", "string"]
+      },
+      "value_type": {
+        "description": "Value type to avoid ambiguity when interpreting it.",
+        "enum": ["bool", "path", "str", "url"],
+        "type": "string"
       }
     },
     "allOf": [
@@ -48,14 +44,10 @@
           }
         },
         "then": {
-          "required": [
-            "value"
-          ]
+          "required": ["value"]
         }
       }
     ],
-    "required": [
-      "name"
-    ]
+    "required": ["name"]
   }
 }

--- a/qgis_deployment_toolbelt/jobs/job_environment_variables.py
+++ b/qgis_deployment_toolbelt/jobs/job_environment_variables.py
@@ -19,6 +19,7 @@ from sys import platform as opersys
 
 # package
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
 from qgis_deployment_toolbelt.utils.win32utils import (
     delete_environment_variable,
     refresh_environment,
@@ -127,6 +128,13 @@ class JobEnvironmentVariables(GenericJob):
         :return str: prepared value.
         """
         try:
+            # check if value is a valid URL
+            if check_str_is_url(input_str=value, raise_error=False):
+                logger.info(
+                    f"{value} is a valid URL. Using it as environment variable value."
+                )
+                return value
+
             # test if value is a path
             value_as_path = Path(expanduser(expandvars(value)))
             if not value_as_path.exists():

--- a/qgis_deployment_toolbelt/utils/url_helpers.py
+++ b/qgis_deployment_toolbelt/utils/url_helpers.py
@@ -1,0 +1,86 @@
+#! python3  # noqa: E265
+
+"""
+    Helpers to check file: readable, exists, etc..
+
+    Author: Julien Moura (https://github.com/guts)
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import logging
+from urllib.parse import urlparse
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+# #############################################################################
+# ########## Functions #############
+# ##################################
+
+
+def check_str_is_url(
+    input_str: str,
+    ref_shemes: tuple = ("http", "https"),
+    raise_error: bool = True,
+):
+    """Checks if a given str is a valid URL.
+
+    Args:
+        input_str (str): The input str to check.
+        ref_schemes (tuple, optional): The reference schemes for valid URLs.
+            By default, it includes ("http", "https").
+        raise_error (bool, optional): Indicates whether an exception should be raised
+            for invalid str. Default is True.
+
+    Returns:
+        bool: True if the str is a valid URL, False otherwise.
+
+    Raises:
+        ValueError: If the str is not a valid URL and `raise_error` is True.
+        TypeError: If an error occurs during str checking and `raise_error` is True.
+    """
+    # convert into str
+    if not isinstance(input_str, str):
+        logger.warning(
+            f"{input_str} is not a str but {type(input_str)}. Take care, "
+            "the conversion is not safe..."
+        )
+        input_str = str(input_str)
+
+    try:
+        parsed_url = urlparse(input_str)
+        if parsed_url.scheme in ref_shemes and parsed_url.netloc:
+            logger.debug(f"{input_str} is a valid URL.")
+            return True
+        else:
+            error_message = f"{input_str} is not a valid URL."
+            if raise_error:
+                raise ValueError(error_message)
+            logger.debug(error_message)
+            return False
+    except ValueError as err:
+        error_message = (
+            f"{input_str} is not a valid URL. An error occurred during "
+            f"check. Trace : {err}"
+        )
+        if raise_error:
+            raise TypeError(error_message)
+        logger.warning(error_message)
+        return False
+
+
+# ############################################################################
+# ##### Stand alone program ########
+# ##################################
+
+if __name__ == "__main__":
+    """Standalone execution."""
+    pass

--- a/tests/test_job_environment_variables.py
+++ b/tests/test_job_environment_variables.py
@@ -56,7 +56,7 @@ class TestJobEnvironmentVariables(unittest.TestCase):
         pass
 
     # -- TESTS ---------------------------------------------------------
-    @unittest.skipIf(opersys != "win32", "Test specific to Windows.")
+    # @unittest.skipIf(opersys != "win32", "Test specific to Windows.")
     def test_environment_variables_set_unset(self):
         """Test YAML loader"""
         fake_env_vars = [

--- a/tests/test_job_environment_variables.py
+++ b/tests/test_job_environment_variables.py
@@ -150,22 +150,22 @@ class TestJobEnvironmentVariables(unittest.TestCase):
         job_env_vars = JobEnvironmentVariables([])
         value_test = f"tests/{Path(__file__).name}"
         self.assertEqual(
-            job_env_vars.prepare_value(value=value_test),
+            job_env_vars.prepare_value(value=value_test, value_type="path"),
             str(Path().resolve() / value_test),
         )
         value_test = "imaginary/path"
         if opersys == "win32":
             self.assertEqual(
-                job_env_vars.prepare_value(value=value_test),
+                job_env_vars.prepare_value(value=value_test, value_type="path"),
                 str(Path().resolve() / value_test),
             )
             self.assertEqual(
-                job_env_vars.prepare_value(value=[]),
+                job_env_vars.prepare_value(value=[], value_type="str"),
                 "[]",
             )
         else:
             self.assertEqual(
-                job_env_vars.prepare_value(value=value_test),
+                job_env_vars.prepare_value(value=value_test, value_type="path"),
                 str(Path().resolve() / value_test),
             )
             self.assertEqual(

--- a/tests/test_job_environment_variables.py
+++ b/tests/test_job_environment_variables.py
@@ -61,6 +61,12 @@ class TestJobEnvironmentVariables(unittest.TestCase):
         """Test YAML loader"""
         fake_env_vars = [
             {
+                "name": "QDT_PROXY_HTTP",
+                "value": "http://proxyhttppronoauth.qdt.com:8080",
+                "scope": "user",
+                "action": "add",
+            },
+            {
                 "name": "QDT_TEST_FAKE_ENV_VAR_BOOL",
                 "value": True,
                 "scope": "user",
@@ -88,9 +94,18 @@ class TestJobEnvironmentVariables(unittest.TestCase):
                 get_environment_variable("QDT_TEST_FAKE_ENV_VAR_PATH"),
                 str(Path(expanduser("~/scripts/qgis_startup.py")).resolve()),
             )
+            self.assertEqual(
+                get_environment_variable("QDT_PROXY_HTTP"),
+                "http://proxyhttppronoauth.qdt.com:8080",
+            )
 
             # clean up
             fake_env_vars = [
+                {
+                    "name": "QDT_PROXY_HTTP",
+                    "scope": "user",
+                    "action": "remove",
+                },
                 {
                     "name": "QDT_TEST_FAKE_ENV_VAR_BOOL",
                     "scope": "user",

--- a/tests/test_job_environment_variables.py
+++ b/tests/test_job_environment_variables.py
@@ -61,22 +61,31 @@ class TestJobEnvironmentVariables(unittest.TestCase):
         """Test YAML loader"""
         fake_env_vars = [
             {
+                "action": "add",
+                "name": "QDT_TEST_ENV_VAR",
+                "scope": "user",
+                "value": "this is a custom value",
+            },
+            {
+                "action": "add",
                 "name": "QDT_PROXY_HTTP",
-                "value": "http://proxyhttppronoauth.qdt.com:8080",
                 "scope": "user",
-                "action": "add",
+                "value": "http://proxy.qdt.com:8080",
+                "value_type": "url",
             },
             {
+                "action": "add",
                 "name": "QDT_TEST_FAKE_ENV_VAR_BOOL",
-                "value": True,
                 "scope": "user",
-                "action": "add",
+                "value": True,
+                "value_type": "bool",
             },
             {
-                "name": "QDT_TEST_FAKE_ENV_VAR_PATH",
-                "value": "~/scripts/qgis_startup.py",
-                "scope": "user",
                 "action": "add",
+                "name": "QDT_TEST_FAKE_ENV_VAR_PATH",
+                "scope": "user",
+                "value": "~/scripts/qgis_startup.py",
+                "value_type": "path",
             },
         ]
         job_env_vars = JobEnvironmentVariables(fake_env_vars)
@@ -96,11 +105,20 @@ class TestJobEnvironmentVariables(unittest.TestCase):
             )
             self.assertEqual(
                 get_environment_variable("QDT_PROXY_HTTP"),
-                "http://proxyhttppronoauth.qdt.com:8080",
+                "http://proxy.qdt.com:8080",
+            )
+            self.assertEqual(
+                get_environment_variable("QDT_TEST_ENV_VAR"),
+                "this is a custom value",
             )
 
             # clean up
             fake_env_vars = [
+                {
+                    "name": "QDT_TEST_ENV_VAR",
+                    "scope": "user",
+                    "action": "remove",
+                },
                 {
                     "name": "QDT_PROXY_HTTP",
                     "scope": "user",

--- a/tests/test_utils_url_helpers.py
+++ b/tests/test_utils_url_helpers.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 # project
 from qgis_deployment_toolbelt.__about__ import __uri__
-from qgis_deployment_toolbelt.utils.url_helpers import check_path_is_url
+from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
 
 # ############################################################################
 # ########## Classes #############
@@ -29,19 +29,15 @@ class TestUtilsUrlHelpers(unittest.TestCase):
 
     def test_check_str_is_url(self):
         """Test function that determines if a str or Path is a valid URL."""
-        self.assertTrue(check_path_is_url(input_path=__uri__))
+        self.assertTrue(check_str_is_url(input_str=__uri__))
         self.assertTrue(
-            check_path_is_url(
-                input_path="ftp://fakeftp:21", ref_shemes=("ftp", "http")
-            ),
+            check_str_is_url(input_str="ftp://fakeftp:21", ref_shemes=("ftp", "http")),
         )
-        self.assertFalse(check_path_is_url(input_path=Path(__uri__), raise_error=False))
-        self.assertFalse(
-            check_path_is_url(input_path=Path(__file__), raise_error=False)
-        )
+        self.assertFalse(check_str_is_url(input_str=Path(__uri__), raise_error=False))
+        self.assertFalse(check_str_is_url(input_str=Path(__file__), raise_error=False))
 
         with self.assertRaises((TypeError, ValueError)):
-            check_path_is_url(input_path=Path(__file__), raise_error=True)
+            check_str_is_url(input_str=Path(__file__), raise_error=True)
 
 
 # ############################################################################

--- a/tests/test_utils_url_helpers.py
+++ b/tests/test_utils_url_helpers.py
@@ -1,0 +1,51 @@
+#! python3  # noqa E265
+
+"""
+    Usage from the repo root folder:
+
+    .. code-block:: bash
+        # for whole tests
+        python -m unittest tests.test_utils_url_helpers
+        # for specific test
+        python -m unittest tests.test_utils_url_helpers.TestUtilsUrlHelpers.test_check_str_is_url
+"""
+
+
+# standard library
+import unittest
+from pathlib import Path
+
+# project
+from qgis_deployment_toolbelt.__about__ import __uri__
+from qgis_deployment_toolbelt.utils.check_path import check_path_is_url
+
+# ############################################################################
+# ########## Classes #############
+# ################################
+
+
+class TestUtilsUrlHelpers(unittest.TestCase):
+    """Test package metadata."""
+
+    def test_check_str_is_url(self):
+        """Test function that determines if a str or Path is a valid URL."""
+        self.assertTrue(check_path_is_url(input_path=__uri__))
+        self.assertTrue(
+            check_path_is_url(
+                input_path="ftp://fakeftp:21", ref_shemes=("ftp", "http")
+            ),
+        )
+        self.assertFalse(check_path_is_url(input_path=Path(__uri__), raise_error=False))
+        self.assertFalse(
+            check_path_is_url(input_path=Path(__file__), raise_error=False)
+        )
+
+        with self.assertRaises((TypeError, ValueError)):
+            check_path_is_url(input_path=Path(__file__), raise_error=True)
+
+
+# ############################################################################
+# ####### Stand-alone run ########
+# ################################
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils_url_helpers.py
+++ b/tests/test_utils_url_helpers.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 # project
 from qgis_deployment_toolbelt.__about__ import __uri__
-from qgis_deployment_toolbelt.utils.check_path import check_path_is_url
+from qgis_deployment_toolbelt.utils.url_helpers import check_path_is_url
 
 # ############################################################################
 # ########## Classes #############
@@ -25,7 +25,7 @@ from qgis_deployment_toolbelt.utils.check_path import check_path_is_url
 
 
 class TestUtilsUrlHelpers(unittest.TestCase):
-    """Test package metadata."""
+    """Test URL helpers."""
 
     def test_check_str_is_url(self):
         """Test function that determines if a str or Path is a valid URL."""


### PR DESCRIPTION
To avoid ambiguity, it adds an option to the [Environment variables manager job](https://guts.github.io/qgis-deployment-cli/jobs/environment_variables.html) allowing user to specify value type:

```yaml
  - name: Set environment variables
    uses: manage-env-vars
    with:
      - name: HTTP_PROXY
        action: "add"
        scope: "user"
        value: "http://proxy.qdt.fr:8080"
        value_type: url
      - name: HTTPS_PROXY
        action: "add"
        scope: "user"
        value: "https://proxy.qdtfr:443"
        value_type: url
      - name: DISABLE_SSL
        action: "add"
        scope: "user"
        value: False
        value_type: bool
      - name: PYQGIS_STARTUP
        action: "add"
        scope: "user"
        value: "~/qgis/startup.py"
        value_type: path
```

Closes #290 