### PR TITLE
Packaging: improve output name and PyInstaller options

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -98,7 +98,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: macos_executable
-          path: dist/*
+          path: |
+              dist/*
+              build_environment_report.txt
           if-no-files-found: error
 
   build-ubuntu:
@@ -131,7 +133,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: ubuntu_executable
-          path: dist/*
+          path: |
+            dist/*
+            build_environment_report.txt
           if-no-files-found: error
 
   build-windows:
@@ -168,7 +172,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows_executable
-          path: dist/*
+          path: |
+            dist/*
+            build_environment_report.txt
           if-no-files-found: error
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ docs/misc/licenses.md
 docs/misc/dependencies.md
 QGISDeploymentToolbelt_*Ubuntu*
 tests/fixtures/tmp/*
+build_environment_report.txt

--- a/builder/pyinstaller_build_macos.py
+++ b/builder/pyinstaller_build_macos.py
@@ -11,6 +11,7 @@
 # Standard library
 import platform
 import sys
+from datetime import datetime
 from os import getenv
 from pathlib import Path
 
@@ -24,7 +25,22 @@ from qgis_deployment_toolbelt import __about__  # noqa: E402
 # #############################################################################
 # ########### MAIN #################
 # ##################################
+# write build report
+build_report = (
+    f"datetime: {datetime.now().astimezone().isoformat()}"
+    f"\nprog_name: {__about__.__title__}"
+    f"\nprog_version: {__about__.__version__}"
+    f"\noperating_system: {platform.system()}"
+    f"\noperating_system_version: {platform.release()}_{platform.version()}"
+    f"\narchitecture: {platform.architecture()[0]}"
+    f"\npython_version: {platform.python_version()}"
+)
+Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF-8")
+
+# variables
+output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
 package_folder = Path("qgis_deployment_toolbelt")
+
 
 mac_os_version, _, _ = platform.mac_ver()
 mac_os_version = "-".join(mac_os_version.split(".")[:2])
@@ -33,19 +49,11 @@ PyInstaller.__main__.run(
     [
         "--add-data=LICENSE:.",
         "--add-data=README.md:.",
-        "--add-data={}:profiles/".format(
-            (package_folder / "profiles/shortcut_freedesktop.template/").resolve()
-        ),
-        "--log-level={}".format(getenv("PYINSTALLER_LOG_LEVEL", "WARN")),
-        "--name={}_{}_MacOS{}_Python{}-{}".format(
-            __about__.__title_clean__,
-            __about__.__version__.replace(".", "-"),
-            mac_os_version,
-            platform.python_version_tuple()[0],
-            platform.python_version_tuple()[1],
-        ),
+        f"--add-data={package_folder.joinpath('profiles/shortcut_freedesktop.template/').resolve()}:profiles/",
+        f"--log-level={getenv('PYINSTALLER_LOG_LEVEL', 'WARN')}",
+        f"--name={output_filename}",
         "--noconfirm",
-        "--noupx",
+        # "--noupx",
         "--onefile",
         "--console",
         str(package_folder / "cli.py"),

--- a/builder/pyinstaller_build_macos.py
+++ b/builder/pyinstaller_build_macos.py
@@ -38,7 +38,9 @@ build_report = (
 Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF-8")
 
 # variables
-output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
+output_filename = (
+    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+)
 package_folder = Path("qgis_deployment_toolbelt")
 
 

--- a/builder/pyinstaller_build_ubuntu.py
+++ b/builder/pyinstaller_build_ubuntu.py
@@ -11,6 +11,7 @@
 # Standard library
 import platform
 import sys
+from datetime import datetime
 from os import getenv
 from pathlib import Path
 
@@ -25,26 +26,32 @@ from qgis_deployment_toolbelt import __about__  # noqa: E402
 # #############################################################################
 # ########### MAIN #################
 # ##################################
+
+# write build report
+build_report = (
+    f"datetime: {datetime.now().astimezone().isoformat()}"
+    f"\nprog_name: {__about__.__title__}"
+    f"\nprog_version: {__about__.__version__}"
+    f"\ndistribution: {distro.name()}"
+    f"\ndistribution_version: {distro.version()}"
+    f"\narchitecture: {platform.architecture()[0]}"
+    f"\npython_version: {platform.python_version()}"
+)
+Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF-8")
+
+
+# variables
+output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
 package_folder = Path("qgis_deployment_toolbelt")
 
 PyInstaller.__main__.run(
     [
         "--add-data=LICENSE:.",
         "--add-data=README.md:.",
-        "--add-data={}:profiles/".format(
-            (package_folder / "profiles/shortcut_freedesktop.template/").resolve()
-        ),
-        "--log-level={}".format(getenv("PYINSTALLER_LOG_LEVEL", "WARN")),
-        "--name={}_{}_{}{}_{}_Python{}".format(
-            __about__.__title_clean__,
-            __about__.__version__,
-            distro.name(),
-            distro.version(),
-            platform.architecture()[0],
-            platform.python_version(),
-        ).replace(".", "-"),
+        f"--add-data={package_folder.joinpath('profiles/shortcut_freedesktop.template/').resolve()}:profiles/",
+        f"--log-level={getenv('PYINSTALLER_LOG_LEVEL', 'WARN')}",
+        f"--name={output_filename}",
         "--noconfirm",
-        "--noupx",
         "--onefile",
         "--console",
         str(package_folder / "cli.py"),

--- a/builder/pyinstaller_build_ubuntu.py
+++ b/builder/pyinstaller_build_ubuntu.py
@@ -41,7 +41,9 @@ Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF
 
 
 # variables
-output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
+output_filename = (
+    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+)
 package_folder = Path("qgis_deployment_toolbelt")
 
 PyInstaller.__main__.run(

--- a/builder/pyinstaller_build_windows.py
+++ b/builder/pyinstaller_build_windows.py
@@ -39,7 +39,9 @@ build_report = (
 Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF-8")
 
 # variables
-output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
+output_filename = (
+    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+)
 package_folder = Path("qgis_deployment_toolbelt")
 
 PyInstaller.__main__.run(

--- a/builder/pyinstaller_build_windows.py
+++ b/builder/pyinstaller_build_windows.py
@@ -11,6 +11,7 @@
 # Standard library
 import platform
 import sys
+from datetime import datetime
 from os import getenv
 from pathlib import Path
 
@@ -24,31 +25,36 @@ from qgis_deployment_toolbelt import __about__  # noqa: E402
 # #############################################################################
 # ########### MAIN #################
 # ##################################
+
+# write build report
+build_report = (
+    f"datetime: {datetime.now().astimezone().isoformat()}"
+    f"\nprog_name: {__about__.__title__}"
+    f"\nprog_version: {__about__.__version__}"
+    f"\noperating_system: {platform.system()}"
+    f"\noperating_system_version: {platform.release()}_{platform.version()}"
+    f"\narchitecture: {platform.architecture()[0]}"
+    f"\npython_version: {platform.python_version()}"
+)
+Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF-8")
+
+# variables
+output_filename = f"{__about__.__title_clean__}_{__about__.__version__}"
 package_folder = Path("qgis_deployment_toolbelt")
 
 PyInstaller.__main__.run(
     [
         "--add-data=LICENSE:.",
         "--add-data=README.md:.",
-        "--add-data={}:profiles/".format(
-            (package_folder / "profiles/shortcut_freedesktop.template/").resolve()
-        ),
         # "--clean",
         f"--icon={package_folder.parent.resolve()}/docs/static/logo_qdt.ico",
-        "--log-level={}".format(getenv("PYINSTALLER_LOG_LEVEL", "WARN")),
-        "--manifest={}".format((package_folder / "../builder/manifest.xml").resolve()),
-        "--name={}_{}_{}{}_Python{}-{}".format(
-            __about__.__title_clean__,
-            __about__.__version__.replace(".", "-"),
-            platform.system(),
-            platform.architecture()[0],
-            platform.python_version_tuple()[0],
-            platform.python_version_tuple()[1],
-        ),
+        f"--log-level={getenv('PYINSTALLER_LOG_LEVEL', 'WARN')}",
+        f"--manifest={Path(__file__).parent.joinpath('manifest.xml')}",
+        f"--name={output_filename}",
         "--noconfirm",
-        "--noupx",
+        # "--noupx",
         "--onefile",
-        "--version-file={}".format("version_info.txt"),
+        "--version-file=version_info.txt",
         "--console",
         str(package_folder / "cli.py"),
     ]

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -4,11 +4,11 @@
 
 The project takes advantage of [PyInstaller](https://pyinstaller.readthedocs.io/) to package the application into an executable.
 
-The output binary and all embedded dependencies is located into a subfolder named: `dist/qgis_deployment_toolbelt_{version}_{operating-system}_Python{python-version}`.
+The output binary and all embedded dependencies is located into a subfolder named: `dist/QGISDeploymentToolbelt_{version}`. A file named `build_environment_report.txt` containing build environment information is generated at the project's root.
 
 ### Windows
 
-> Comply with [Windows development requirements](windows) before to run.
+> Comply with [Windows development requirements](../development/windows.md) before to run.
 
 ```powershell
 # Generates MS Version Info
@@ -18,24 +18,25 @@ python .\builder\version_info_templater.py
 python -O .\builder\pyinstaller_build_windows.py
 ```
 
-![QGIS Deployment Toolbelt - Executable properties](/static/executable_windows_properties_details.png)
+![QGIS Deployment Toolbelt - Executable properties](../static/executable_windows_properties_details.png)
 
 To run it, double-click on the executable file (*.exe).
 
 ### Ubuntu
 
-> Comply with [Ubuntu development requirements](ubuntu) before to run.
+> Comply with [Ubuntu development requirements](../development/ubuntu.md) before to run.
 
-```bash
+```sh
 # Generates binary executable
 python -O ./builder/pyinstaller_build_ubuntu.py
+# make it runnable
+chmod +x dist/QGISDeploymentToolbelt_*
 ```
 
 To run it, for example:
 
-```bash
-cd dist/qgis_deployment_toolbelt_3-0-0_Ubuntu20-04_64bit_Python3-8-5/
-./qgis_deployment_toolbelt_3-0-0_Ubuntu20-04_64bit_Python3-8-5
+```sh
+./dist/QGISDeploymentToolbelt_0-26-0
 ```
 
 ----


### PR DESCRIPTION
- change executable name from ` QGISDeploymentToolbelt_0-26-0_Windows64bit_Python3-11.exe ` to `QGISDeploymentToolbelt_0-26-0.exe` cc @jmkerloch 
- let PyInstaller deciding use UPX or not
- generate a build report to keep a trace accross CI/CD
- minor improvments in builder scripts (f-strings...)
- update packaging documentation consequently