### PR TITLE
Packaging: renamed license to match Pypi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Information Technology",
-        "License :: OSI Approved :: Apache Software License 2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: Microsoft :: Windows :: Windows 10",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Make license classifiers compatible with PyPI to fix error during publishing (https://github.com/Guts/qgis-deployment-cli/actions/runs/6799893590/job/18487221639):

Upstream:

- https://github.com/pypi/legacy/issues/91
- https://github.com/pypa/trove-classifiers/issues/17