### PR TITLE
Publishing to PyPi: switch to trusted publisher

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -220,6 +220,11 @@ jobs:
     name: "🐍 Release on PyPI"
     runs-on: ubuntu-latest
     needs: [build-python-wheel]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qgis-deployment-toolbelt
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -240,11 +245,10 @@ jobs:
           name: python_wheel
           path: builds/wheel/
 
-      - name: Publish on PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload builds/wheel/*
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: builds/wheel/*
 
   release-ghcr:
     name: "🐳 Release as Docker container"


### PR DESCRIPTION
Trusted Publishers is the latest secured (OpenID Connect) way to publish to PyPi. It does not require to store any credential or token in GitHub.

For more information, see: https://docs.pypi.org/trusted-publishers/