### PR TITLE
Packaging: restore operating system name in final executables

### DIFF
--- a/builder/pyinstaller_build_macos.py
+++ b/builder/pyinstaller_build_macos.py
@@ -39,7 +39,7 @@ Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF
 
 # variables
 output_filename = (
-    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+    f"MacOS_{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
 )
 package_folder = Path("qgis_deployment_toolbelt")
 

--- a/builder/pyinstaller_build_ubuntu.py
+++ b/builder/pyinstaller_build_ubuntu.py
@@ -42,7 +42,7 @@ Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF
 
 # variables
 output_filename = (
-    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+    f"Ubuntu_{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
 )
 package_folder = Path("qgis_deployment_toolbelt")
 

--- a/builder/pyinstaller_build_windows.py
+++ b/builder/pyinstaller_build_windows.py
@@ -40,7 +40,7 @@ Path("build_environment_report.txt").write_text(data=build_report, encoding="UTF
 
 # variables
 output_filename = (
-    f"{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
+    f"Windows_{__about__.__title_clean__}_{__about__.__version__.replace('.', '-')}"
 )
 package_folder = Path("qgis_deployment_toolbelt")
 

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -4,7 +4,7 @@
 
 The project takes advantage of [PyInstaller](https://pyinstaller.readthedocs.io/) to package the application into an executable.
 
-The output binary and all embedded dependencies is located into a subfolder named: `dist/QGISDeploymentToolbelt_{version}`. A file named `build_environment_report.txt` containing build environment information is generated at the project's root.
+The output binary and all embedded dependencies is located into a subfolder named `dist`: `dist/{operating_system}_QGISDeploymentToolbelt_{version}`, where operating system is one of `MacOS`, `Ubuntu`or `Windows`. A file named `build_environment_report.txt` containing build environment information is generated at the project's root.
 
 ### Windows
 


### PR DESCRIPTION
Because names are used in upgrade command to retrieve the matching operating system release's asset.

I've created an issue in the GitHub Action used to publish to GitHub Release to set label property: https://github.com/softprops/action-gh-release/issues/394