### PR TITLE
Refacto: add a Git handler base class to inherit from and avoid duplicate code

### DIFF
--- a/examples/profiles/Viewer Mode/QGIS/QGISCUSTOMIZATION3.ini
+++ b/examples/profiles/Viewer Mode/QGIS/QGISCUSTOMIZATION3.ini
@@ -2203,6 +2203,4 @@ Widgets\SimplifyLineDialog\okButton=true
 Widgets\SimplifyLineDialog\spinBox=true
 Widgets\SimplifyLineDialog\spinBox\qt_spinbox_lineedit=true
 status=1
-
-[Customization]
 splashpath=/home/jmo/Git/Oslandia/QGIS/qgis-deployment-cli/examples/profiles/Viewer Mode/images/

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -138,13 +138,13 @@ class JobProfilesDownloader(GenericJob):
         if self.options.get("protocol") == "git":
             if self.options.get("source").startswith(("git://", "http://", "https://")):
                 downloader = RemoteGitHandler(
-                    uri_or_path=self.options.get("source"),
+                    remote_git_uri_or_path=self.options.get("source"),
                     branch=self.options.get("branch", "master"),
                 )
                 downloader.download(local_path=self.qdt_working_folder)
             elif self.options.get("source").startswith("file://"):
                 downloader = LocalGitHandler(
-                    uri_or_path=self.options.get("source"),
+                    remote_git_uri_or_path=self.options.get("source"),
                     branch=self.options.get("branch", "master"),
                 )
                 downloader.download(local_path=self.qdt_working_folder)

--- a/qgis_deployment_toolbelt/profiles/git_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/git_handler_base.py
@@ -1,0 +1,264 @@
+#! python3  # noqa: E265
+
+"""
+    Handle remote git repository.
+
+    Author: Julien Moura (https://github.com/guts).
+
+    Inspired from: QGIS Resource Sharing
+"""
+
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import logging
+from pathlib import Path
+from shutil import rmtree
+from typing import Literal
+
+# 3rd party
+from dulwich import porcelain
+from dulwich.errors import GitProtocolError, NotGitRepository
+from dulwich.repo import Repo
+from giturlparse import GitUrlParsed
+from giturlparse import parse as git_parse
+from giturlparse import validate as git_validate
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+class GitHandlerBase:
+    """Common git repository handler using dulwich.
+
+    It's designed to handle thoses cases:
+
+    - the distant repository is on a local network or drive
+    - the distant repository is on Internet (github.com, gitlab.com, gitlab.company.org...)
+    - the local repository is on a local network or drive
+    """
+
+    distant_git_repository_path_or_url: Path | str | None = None
+    distant_git_repository_type: Literal["local", "remote"] | None = None
+    distant_git_repository_branch: str | None = None
+
+    local_git_repository_path: Path | None = None
+    local_git_repository_active_branch: str | None = None
+
+    def url_parsed(self, remote_git_url: str) -> GitUrlParsed:
+        """Return URL parsed to extract git information.
+
+        Returns:
+            GitUrlParsed: parsed URL object
+        """
+        return git_parse(remote_git_url)
+
+    def is_local_path_git_repository(self, local_path: Path) -> bool:
+        """Flag if local folder is a git repository.
+
+        Args:
+            local_path (Path): path to check
+
+        Returns:
+            bool: True if there is a .git subfolder
+        """
+        try:
+            Repo(root=f"{local_path.resolve()}")
+            return True
+        except NotGitRepository as err:
+            logger.error(f"{local_path} is not a valid Git repository. Trace: {err}")
+            return False
+        except Exception as err:
+            logger.error(
+                f"Something went wrong when checking if {local_path} is a valid "
+                f"Git repository. Trace: {err}"
+            )
+            return False
+
+    def is_url_git_repository(self, remote_git_url: str) -> bool:
+        """Flag if the remote URL is a git repository.
+
+        Args:
+            remote_git_url (str): URL pointing to a remote git repository.
+
+        Returns:
+            bool: True if the URL is a valid git repository.
+        """
+        return git_validate(remote_git_url)
+
+    def download(self, local_path: str | Path) -> Repo:
+        """Generic wrapper around the specific logic of this handler.
+
+        Args:
+            local_path (str | Path): path to the local folder where to download
+
+        Returns:
+            Repo: the local repository object
+        """
+        local_git_repository = self.clone_or_pull(local_path)
+        if isinstance(local_git_repository, Repo):
+            self.local_git_repository_active_branch = porcelain.active_branch(
+                local_git_repository
+            )
+        return local_git_repository
+
+    def clone_or_pull(self, local_path: str | Path) -> Repo:
+        """Clone or pull remote repository to local path. If this one doesn't exist,
+        it's created. If fetch or pull action fail, it removes the existing folder and
+        clone the remote again.
+
+        Args:
+            local_path (str | Path): path to the folder where to clone (or pull)
+
+        Raises:
+            err: if something fails during clone or pull operations
+
+        Returns:
+            Repo: the local repository object
+        """
+        # convert to path
+        if isinstance(local_path, str):
+            local_path = Path(local_path)
+
+        # clone
+        if local_path.exists() and not self.is_local_path_git_repository(local_path):
+            try:
+                return self._clone(local_path=local_path)
+            except Exception as err:
+                logger.error(
+                    f"Error cloning the remote repository {self.distant_git_repository_path_or_url} "
+                    f"(branch {self.distant_git_repository_branch}) to {local_path}. "
+                    f"Trace: {err}."
+                )
+                raise err
+        elif local_path.exists() and self.is_local_path_git_repository(local_path):
+            # FETCH
+            try:
+                self._fetch(local_path=local_path)
+            except GitProtocolError as error:
+                logger.error(
+                    f"Error fetching {self.distant_git_repository_path_or_url} "
+                    f"repository to {local_path.resolve()}. Trace: {error}."
+                    "Trying to remove the local folder and cloning again..."
+                )
+                rmtree(path=local_path, ignore_errors=True)
+                return self.clone_or_pull(local_path=local_path)
+            # PULL
+            try:
+                return self._pull(local_path=local_path)
+            except GitProtocolError as error:
+                logger.error(
+                    f"Error pulling {self.distant_git_repository_path_or_url} "
+                    f"repository to {local_path.resolve()}. Trace: {error}."
+                    "Trying to remove the local folder and cloning again..."
+                )
+                rmtree(path=local_path, ignore_errors=True)
+                return self.clone_or_pull(local_path=local_path)
+        elif not local_path.exists():
+            logger.debug(
+                f"Local path does not exists: {local_path.as_uri()}. "
+                "Creating it and trying again..."
+            )
+            local_path.mkdir(parents=True, exist_ok=True)
+            return self.clone_or_pull(local_path=local_path)
+
+    def _clone(self, local_path: Path) -> Repo:
+        """Clone the remote repository to local path.
+
+        Args:
+            local_path (Path): path to the folder where to clone
+
+        Returns:
+            Repo: the local repository object
+        """
+        # clone
+        logger.info(
+            f"Cloning repository {self.distant_git_repository_path_or_url} to {local_path}"
+        )
+        local_repo = porcelain.clone(
+            source=self.distant_git_repository_path_or_url,
+            target=f"{local_path.resolve()}",
+            branch=self.distant_git_repository_branch,
+            depth=0,
+        )
+        gobj = local_repo.get_object(local_repo.head())
+        logger.debug(
+            f"Active branch: {porcelain.active_branch(local_repo)}. "
+            f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
+            f" at {gobj.commit_time}."
+        )
+        return local_repo
+
+    def _fetch(self, local_path: Path) -> Repo:
+        """Fetch the remote repository from the existing local repository.
+
+        Args:
+            local_path (Path): path to the folder where to fetch
+
+        Returns:
+            Repo: the local repository object
+        """
+        # with porcelain.open_repo_closing(str(local_path.resolve())) as local_repo:
+        logger.info(
+            f"Fetching repository {self.distant_git_repository_path_or_url} to {local_path}",
+        )
+        local_repo = Repo(root=f"{local_path.resolve()}")
+        porcelain.fetch(
+            repo=f"{local_path.resolve()}",
+            remote_location=self.distant_git_repository_path_or_url,
+            force=True,
+            prune=True,
+            prune_tags=True,
+            depth=0,
+        )
+        logger.debug(
+            f"Repository {local_path.resolve()} has been fetched from "
+            f"remote {self.distant_git_repository_path_or_url}. "
+            f"Local active branch: {porcelain.active_branch(local_repo)}."
+        )
+
+    def _pull(self, local_path: Path) -> Repo:
+        """Pull the remote repository from the existing local repository.
+
+        Args:
+            local_path (Path): path to the folder where to pull
+
+        Returns:
+            Repo: the local repository object
+        """
+        local_repo = Repo(root=f"{local_path.resolve()}")
+        logger.info(
+            f"Pulling repository {self.distant_git_repository_path_or_url} to {local_path}"
+        )
+        porcelain.pull(
+            repo=local_path,
+            remote_location=self.distant_git_repository_path_or_url,
+            force=True,
+        )
+        gobj = local_repo.get_object(local_repo.head())
+        logger.debug(
+            f"Repository {local_path.resolve()} has been pulled. "
+            f"Local active branch: {porcelain.active_branch(local_repo)}. "
+            f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
+            f" at {gobj.commit_time}"
+        )
+        return local_repo
+
+
+# #############################################################################
+# ##### Stand alone program ########
+# ##################################
+
+if __name__ == "__main__":
+    """Standalone execution."""
+    pass

--- a/qgis_deployment_toolbelt/profiles/local_git_handler.py
+++ b/qgis_deployment_toolbelt/profiles/local_git_handler.py
@@ -16,12 +16,12 @@
 # Standard library
 import logging
 from pathlib import Path
-from shutil import rmtree
 
 # 3rd party
-from dulwich import porcelain
-from dulwich.errors import GitProtocolError, NotGitRepository
-from dulwich.repo import Repo
+from dulwich.errors import NotGitRepository
+
+# project
+from qgis_deployment_toolbelt.profiles.git_handler_base import GitHandlerBase
 
 # #############################################################################
 # ########## Globals ###############
@@ -34,199 +34,43 @@ logger = logging.getLogger(__name__)
 # #############################################################################
 # ########## Classes ###############
 # ##################################
-class LocalGitHandler:
+class LocalGitHandler(GitHandlerBase):
     """Handle local git repository."""
 
-    def __init__(self, uri_or_path: str | Path, branch: str = None) -> None:
+    def __init__(
+        self, remote_git_uri_or_path: str | Path, branch: str | None = None
+    ) -> None:
         """Constructor.
 
         Args:
-            uri_or_path (Union[str, Path]): input URI (file://...) or path (S://)
+            remote_git_uri_or_path (Union[str, Path]): input URI (file://...) or path (S://)
             branch (str, optional): default branch name. Defaults to None.
 
         Raises:
             NotGitRepository: if uri_or_path doesn't point to a valid Git repository
         """
+        self.distant_git_repository_type = "local"
+
+        # clean up
+        if remote_git_uri_or_path.startswith("file://"):
+            remote_git_uri_or_path = remote_git_uri_or_path[7:]
+            logger.debug(
+                f"URI cleaning: 'file://' protocol prefix removed. Result: {remote_git_uri_or_path}"
+            )
+        if remote_git_uri_or_path.endswith(".git"):
+            logger.debug(
+                f"URI cleaning: '.git' suffix removed. Result: {remote_git_uri_or_path}"
+            )
+            remote_git_uri_or_path = remote_git_uri_or_path[:-4]
+
         # validation
-        if uri_or_path.startswith("file://"):
-            uri_or_path = uri_or_path[7:]
-            logger.debug(
-                f"URI cleaning: 'file://' protocol prefix removed. Result: {uri_or_path}"
-            )
-        if uri_or_path.endswith(".git"):
-            logger.debug(f"URI cleaning: '.git' suffix removed.Result: {uri_or_path}")
-            uri_or_path = uri_or_path[:-4]
-
-        self.url = uri_or_path
-        if not self.is_url_git_repository:
-            raise NotGitRepository(f"{uri_or_path} is not a valid Git repository.")
-
-        self.branch = branch
-
-    @property
-    def is_url_git_repository(self) -> bool:
-        """Flag if a repository is a git repository.
-
-        Returns:
-            bool: True if the URL is a valid git repository.
-        """
-        try:
-            Repo(self.url)
-            return True
-        except NotGitRepository as err:
-            logger.error(f"{self.url} is not a valid Git repository. Trace: {err}")
-            return False
-        except Exception as err:
-            logger.error(
-                f"Somehting went wrong when checking if {self.url} is a valid "
-                f"Git repository. Trace: {err}"
+        if not self.is_local_path_git_repository(remote_git_uri_or_path):
+            raise NotGitRepository(
+                f"{remote_git_uri_or_path} is not a valid Git repository."
             )
 
-    def download(self, local_path: str | Path) -> Repo:
-        """Generic wrapper around the specific logic of this handler.
-
-        Args:
-            local_path (str | Path): path to the local folder where to download
-
-        Returns:
-            Repo: the local repository object
-        """
-        return self.clone_or_pull(local_path)
-
-    def is_local_path_git_repository(self, local_path: str | Path) -> bool:
-        """Flag if local folder is a git repository.
-
-        Args:
-            local_path (str | Path): path to check
-
-        Returns:
-            bool: True if there is a .git subfolder
-        """
-        return Path(local_path / ".git").is_dir()
-
-    def clone_or_pull(self, local_path: str | Path) -> Repo:
-        """Clone or pull remote repository to local path. If this one doesn't exist,
-        it's created. If fetch or pull action fail, it removes the existing folder and
-        clone the remote again.
-
-        Args:
-            local_path (str | Path): path to the folder where to clone (or pull)
-
-        Raises:
-            err: if something fails during clone or pull operations
-
-        Returns:
-            Repo: the local repository object
-        """
-
-        # convert to path
-        if isinstance(local_path, str):
-            local_path = Path(local_path)
-
-        # clone
-        if local_path.exists() and not self.is_local_path_git_repository(local_path):
-            try:
-                return self._clone(local_path=local_path)
-            except Exception as err:
-                logger.error(
-                    f"Error cloning the remote repository {self.url} "
-                    f"(branch {self.branch}) to {local_path}. "
-                    f"Trace: {err}."
-                )
-                raise err
-        elif local_path.exists() and self.is_local_path_git_repository(local_path):
-            # FETCH
-            try:
-                self._fetch(local_path=local_path)
-            except GitProtocolError as error:
-                logger.error(
-                    f"Error fetching {self.url} repository to "
-                    f"{local_path.resolve()}. Trace: {error}."
-                    "Trying to remove the local folder and cloning again..."
-                )
-                rmtree(path=local_path, ignore_errors=True)
-                return self.clone_or_pull(local_path=local_path)
-            # PULL
-            try:
-                return self._pull(local_path=local_path)
-            except GitProtocolError as error:
-                logger.error(
-                    f"Error fetching {self.url} repository to "
-                    f"{local_path.resolve()}. Trace: {error}."
-                    "Trying to remove the local folder and cloning again..."
-                )
-                rmtree(path=local_path, ignore_errors=True)
-                return self.clone_or_pull(local_path=local_path)
-        elif not local_path.exists():
-            logger.debug(
-                f"Local path does not exists: {local_path.as_uri()}. "
-                "Creating it and trying again..."
-            )
-            local_path.mkdir(parents=True, exist_ok=True)
-            return self.clone_or_pull(local_path)
-
-    def _clone(self, local_path: str | Path) -> Repo:
-        """Clone the remote repository to local path.
-
-        Args:
-            local_path (str | Path): path to the folder where to clone
-
-        Returns:
-            Repo: the local repository object
-        """
-        # clone
-        if local_path.exists() and not self.is_local_path_git_repository(local_path):
-            logger.info(f"Cloning repository {self.url} to {local_path}")
-            local_repo = porcelain.clone(
-                source=self.url,
-                target=str(local_path.resolve()),
-                branch=self.branch,
-            )
-            gobj = local_repo.get_object(local_repo.head())
-            logger.debug(
-                f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
-                f" at {gobj.commit_time}"
-            )
-            return local_repo
-
-    def _fetch(self, local_path: str | Path) -> Repo:
-        """Fetch the remote repository from the existing local repository.
-
-        Args:
-            local_path (str | Path): path to the folder where to fetch
-
-        Returns:
-            Repo: the local repository object
-        """
-        with porcelain.open_repo_closing(str(local_path.resolve())) as local_repo:
-            logger.info(
-                f"Fetching repository {self.url} to {local_path}",
-            )
-            porcelain.fetch(
-                repo=local_repo,
-                remote_location=self.url,
-                force=True,
-                prune=True,
-            )
-
-    def _pull(self, local_path: str | Path) -> Repo:
-        """Pull the remote repository from the existing local repository.
-
-        Args:
-            local_path (str | Path): path to the folder where to pull
-
-        Returns:
-            Repo: the local repository object
-        """
-        with porcelain.open_repo_closing(str(local_path.resolve())) as local_repo:
-            logger.info(f"Pulling repository {self.url} to {local_path}")
-            porcelain.pull(repo=local_repo, remote_location=self.url, force=True)
-            gobj = local_repo.get_object(local_repo.head())
-            logger.debug(
-                f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
-                f" at {gobj.commit_time}"
-            )
-        return local_repo
+        self.distant_git_repository_path_or_url = remote_git_uri_or_path
+        self.distant_git_repository_branch = branch
 
 
 # #############################################################################

--- a/qgis_deployment_toolbelt/profiles/remote_git_handler.py
+++ b/qgis_deployment_toolbelt/profiles/remote_git_handler.py
@@ -15,16 +15,12 @@
 
 # Standard library
 import logging
-from pathlib import Path
-from shutil import rmtree
 
 # 3rd party
-from dulwich import porcelain
-from dulwich.errors import GitProtocolError
-from dulwich.repo import Repo
-from giturlparse import GitUrlParsed
-from giturlparse import parse as git_parse
 from giturlparse import validate as git_validate
+
+# project
+from qgis_deployment_toolbelt.profiles.git_handler_base import GitHandlerBase
 
 # #############################################################################
 # ########## Globals ###############
@@ -37,187 +33,31 @@ logger = logging.getLogger(__name__)
 # #############################################################################
 # ########## Classes ###############
 # ##################################
-class RemoteGitHandler:
+class RemoteGitHandler(GitHandlerBase):
     """Handle remote git repository."""
 
-    def __init__(self, uri_or_path: str, branch: str = None) -> None:
+    def __init__(self, remote_git_uri_or_path: str, branch: str | None = None) -> None:
         """Constructor.
 
         Args:
-            uri_or_path (Union[str, Path]): input URI (http://, https://, git://)
+            remote_git_uri_or_path (Union[str, Path]): input URI (http://, https://, git://)
             branch (str, optional): default branch name. Defaults to None.
 
         """
+        self.distant_git_repository_type = "remote"
+
         # validation
-        if not git_validate(uri_or_path):
-            raise ValueError(f"Invalid git URL: {uri_or_path}")
-        self.url = uri_or_path
-        self.branch = branch or self.url_parsed.branch
+        if not git_validate(remote_git_uri_or_path):
+            raise ValueError(f"Invalid git URL: {remote_git_uri_or_path}")
 
-    @property
-    def is_url_git_repository(self) -> bool:
-        """Flag if a repository is a git repository.
+        self.distant_git_repository_path_or_url = remote_git_uri_or_path
 
-        Returns:
-            bool: True if the URL is a valid git repository.
-        """
-        return git_validate(self.url)
-
-    @property
-    def url_parsed(self) -> GitUrlParsed:
-        """Return URL parsed to extract git information.
-
-        Returns:
-            GitUrlParsed: parsed URL object
-        """
-        return git_parse(self.url)
-
-    def download(self, local_path: str | Path) -> Repo:
-        """Generic wrapper around the specific logic of this handler.
-
-        Args:
-            local_path (str | Path): path to the local folder where to download
-
-        Returns:
-            Repo: the local repository object
-        """
-        return self.clone_or_pull(local_path)
-
-    def is_local_path_git_repository(self, local_path: str | Path) -> bool:
-        """Flag if local folder is a git repository.
-
-        Args:
-            local_path (str | Path): path to check
-
-        Returns:
-            bool: True if there is a .git subfolder
-        """
-        return Path(local_path / ".git").is_dir()
-
-    def clone_or_pull(self, local_path: str | Path) -> Repo:
-        """Clone or pull remote repository to local path. If this one doesn't exist,
-        it's created. If fetch or pull action fail, it removes the existing folder and
-        clone the remote again.
-
-        Args:
-            local_path (str | Path): path to the folder where to clone (or pull)
-
-        Raises:
-            err: if something fails during clone or pull operations
-
-        Returns:
-            Repo: the local repository object
-        """
-        # convert to path
-        if isinstance(local_path, str):
-            local_path = Path(local_path)
-
-        # clone
-        if local_path.exists() and not self.is_local_path_git_repository(local_path):
-            try:
-                return self._clone(local_path=local_path)
-            except Exception as err:
-                logger.error(
-                    f"Error cloning the remote repository {self.url} "
-                    f"(branch {self.branch}) to {local_path}. "
-                    f"Trace: {err}."
-                )
-                raise err
-        elif local_path.exists() and self.is_local_path_git_repository(local_path):
-            # FETCH
-            try:
-                self._fetch(local_path=local_path)
-            except GitProtocolError as error:
-                logger.error(
-                    f"Error fetching {self.url} repository to "
-                    f"{local_path.resolve()}. Trace: {error}."
-                    "Trying to remove the local folder and cloning again..."
-                )
-                rmtree(path=local_path, ignore_errors=True)
-                return self.clone_or_pull(local_path=local_path)
-            # PULL
-            try:
-                return self._pull(local_path=local_path)
-            except GitProtocolError as error:
-                logger.error(
-                    f"Error fetching {self.url} repository to "
-                    f"{local_path.resolve()}. Trace: {error}."
-                    "Trying to remove the local folder and cloning again..."
-                )
-                rmtree(path=local_path, ignore_errors=True)
-                return self.clone_or_pull(local_path=local_path)
-        elif not local_path.exists():
-            logger.debug(
-                f"Local path does not exists: {local_path.as_uri()}. "
-                "Creating it and trying again..."
-            )
-            local_path.mkdir(parents=True, exist_ok=True)
-            return self.clone_or_pull(local_path)
-
-    def _clone(self, local_path: str | Path) -> Repo:
-        """Clone the remote repository to local path.
-
-        Args:
-            local_path (str | Path): path to the folder where to clone
-
-        Returns:
-            Repo: the local repository object
-        """
-        # clone
-        if local_path.exists() and not self.is_local_path_git_repository(local_path):
-            logger.info(f"Cloning repository {self.url} to {local_path}")
-            local_repo = porcelain.clone(
-                source=self.url,
-                target=str(local_path.resolve()),
-                branch=self.branch,
-                depth=5,
-            )
-            gobj = local_repo.get_object(local_repo.head())
-            logger.debug(
-                f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
-                f" at {gobj.commit_time}"
-            )
-            return local_repo
-
-    def _fetch(self, local_path: str | Path) -> Repo:
-        """Fetch the remote repository from the existing local repository.
-
-        Args:
-            local_path (str | Path): path to the folder where to fetch
-
-        Returns:
-            Repo: the local repository object
-        """
-        with porcelain.open_repo_closing(str(local_path.resolve())) as local_repo:
-            logger.info(
-                f"Fetching repository {self.url} to {local_path}",
-            )
-            porcelain.fetch(
-                repo=local_repo,
-                remote_location=self.url,
-                force=True,
-                prune=True,
-                depth=5,
-            )
-
-    def _pull(self, local_path: str | Path) -> Repo:
-        """Pull the remote repository from the existing local repository.
-
-        Args:
-            local_path (str | Path): path to the folder where to pull
-
-        Returns:
-            Repo: the local repository object
-        """
-        with porcelain.open_repo_closing(str(local_path.resolve())) as local_repo:
-            logger.info(f"Pulling repository {self.url} to {local_path}")
-            porcelain.pull(repo=local_repo, remote_location=self.url, force=True)
-            gobj = local_repo.get_object(local_repo.head())
-            logger.debug(
-                f"Latest commit cloned: {gobj.sha().hexdigest()} by {gobj.author}"
-                f" at {gobj.commit_time}"
-            )
-        return local_repo
+        if isinstance(branch, (str, bytes)):
+            self.distant_git_repository_branch = branch
+        else:
+            self.distant_git_repository_branch = self.url_parsed(
+                self.distant_git_repository_path_or_url
+            ).branch
 
 
 # #############################################################################

--- a/tests/dev/dev_dulwich_remote.py
+++ b/tests/dev/dev_dulwich_remote.py
@@ -1,0 +1,68 @@
+import logging
+from pathlib import Path
+
+from dulwich import porcelain
+from dulwich.repo import Repo
+
+from qgis_deployment_toolbelt.profiles.remote_git_handler import RemoteGitHandler
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s||%(levelname)s||%(module)s||%(lineno)d||%(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+git_repository_remote_url = "https://github.com/Guts/qgis-deployment-cli.git"
+git_repository_local = Path(__file__).parent.parent.joinpath(
+    "fixtures/tmp/dev_repository/"
+)
+# git_repository_local.mkdir(parents=True, exist_ok=True)
+
+# -- WITH DULWICH --
+print("\n\n-- WORKING WITH DULWICH --")
+git_repository_local_dulwich = git_repository_local.joinpath("dulwich")
+if (
+    git_repository_local_dulwich.is_dir()
+    and git_repository_local_dulwich.joinpath(".git").is_dir()
+):
+    print(
+        f"{git_repository_local_dulwich.resolve()} is a git local project ---> let's FETCH then PULL"
+    )
+    dul_local_repo = Repo(root=f"{git_repository_local_dulwich.resolve()}")
+    porcelain.fetch(
+        repo=dul_local_repo,
+        remote_location=git_repository_remote_url,
+        force=True,
+        prune=True,
+    )
+
+    porcelain.pull(
+        repo=dul_local_repo,
+        remote_location=git_repository_remote_url,
+        force=True,
+        fast_forward=True,
+    )
+else:
+    git_repository_local_dulwich.mkdir(parents=True, exist_ok=True)
+    print(
+        f"{git_repository_local_dulwich.resolve()} is not a git local project ---> let's CLONE"
+    )
+    dul_local_repo = porcelain.clone(
+        source=git_repository_remote_url,
+        target=f"{git_repository_local_dulwich.resolve()}",
+    )
+
+# get local active branch
+active_branch = porcelain.active_branch(repo=dul_local_repo)
+print(f"\nLocal active branch {active_branch.decode()}")
+
+dul_local_repo.close()
+# assert dul_repo == dul_local_repo
+
+# -- WITH QDT --
+print("\n\n-- WORKING WITH QDT --")
+git_repository_local_dulwich = git_repository_local.joinpath("dulwich")
+remote_git_handler = RemoteGitHandler(remote_git_uri_or_path=git_repository_remote_url)
+
+remote_git_handler.clone_or_pull(local_path=git_repository_local_dulwich)

--- a/tests/test_git_handler.py
+++ b/tests/test_git_handler.py
@@ -76,32 +76,33 @@ class TestGitHandler(unittest.TestCase):
         """Test git parsed URL"""
         self.good_git_url = "https://gitlab.com/Oslandia/qgis/profils_qgis_fr_2022.git"
         git_handler = RemoteGitHandler(self.good_git_url)
+        git_url_parsed = git_handler.url_parsed(self.good_git_url)
 
         # type
-        self.assertIsInstance(git_handler.url_parsed, GitUrlParsed)
+        self.assertIsInstance(git_url_parsed, GitUrlParsed)
 
         # keys
-        self.assertIn("branch", git_handler.url_parsed.data)
-        self.assertIn("domain", git_handler.url_parsed.data)
-        self.assertIn("groups_path", git_handler.url_parsed.data)
-        self.assertIn("owner", git_handler.url_parsed.data)
-        self.assertIn("path", git_handler.url_parsed.data)
-        self.assertIn("path_raw", git_handler.url_parsed.data)
-        self.assertIn("pathname", git_handler.url_parsed.data)
-        self.assertIn("platform", git_handler.url_parsed.data)
-        self.assertIn("port", git_handler.url_parsed.data)
-        self.assertIn("protocol", git_handler.url_parsed.data)
-        self.assertIn("protocols", git_handler.url_parsed.data)
-        self.assertIn("repo", git_handler.url_parsed.data)
-        self.assertIn("url", git_handler.url_parsed.data)
+        self.assertIn("branch", git_url_parsed.data)
+        self.assertIn("domain", git_url_parsed.data)
+        self.assertIn("groups_path", git_url_parsed.data)
+        self.assertIn("owner", git_url_parsed.data)
+        self.assertIn("path", git_url_parsed.data)
+        self.assertIn("path_raw", git_url_parsed.data)
+        self.assertIn("pathname", git_url_parsed.data)
+        self.assertIn("platform", git_url_parsed.data)
+        self.assertIn("port", git_url_parsed.data)
+        self.assertIn("protocol", git_url_parsed.data)
+        self.assertIn("protocols", git_url_parsed.data)
+        self.assertIn("repo", git_url_parsed.data)
+        self.assertIn("url", git_url_parsed.data)
 
         # values
-        self.assertIn("gitlab.com", git_handler.url_parsed.domain)
-        self.assertIn("gitlab.com", git_handler.url_parsed.host)
-        self.assertEqual("qgis", git_handler.url_parsed.groups_path)
-        self.assertEqual("Oslandia", git_handler.url_parsed.owner)
-        self.assertEqual("gitlab", git_handler.url_parsed.platform)
-        self.assertEqual("profils_qgis_fr_2022", git_handler.url_parsed.repo)
+        self.assertIn("gitlab.com", git_url_parsed.domain)
+        self.assertIn("gitlab.com", git_url_parsed.host)
+        self.assertEqual("qgis", git_url_parsed.groups_path)
+        self.assertEqual("Oslandia", git_url_parsed.owner)
+        self.assertEqual("gitlab", git_url_parsed.platform)
+        self.assertEqual("profils_qgis_fr_2022", git_url_parsed.repo)
 
     @unittest.skipUnless(version_info.minor >= 10, "requires python 3.10")
     def test_git_clone_py310(self):


### PR DESCRIPTION
- add a class `GitHandlerBase` and make `LocalGitHandler` and `RemoteGitHandler` inherit from to mutualize code
- fix profiles sync which was stucked during fetch