### PR TITLE
Change: move QDT subfolders to generic job

### DIFF
--- a/examples/scenarios/demo-scenario.qdt.yml
+++ b/examples/scenarios/demo-scenario.qdt.yml
@@ -8,7 +8,7 @@ metadata:
 
 # Toolbelt settings
 settings:
-  LOCAL_WORK_DIR: ~/.cache/qgis-deployment-toolbelt/demo/
+  # LOCAL_WORK_DIR: ~/.cache/qgis-deployment-toolbelt/demo/
   # QGIS_EXE_PATH:
   #   linux: /usr/bin/qgis
   #   mac: /usr/bin/qgis

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -39,48 +39,54 @@ DEFAULT_QDT_WORKING_FOLDER = Path.home().joinpath(".cache/qgis-deployment-toolbe
 
 
 def get_qdt_working_directory(
-    specific_value: PathLike | None = None, identifier: str = "default"
+    specific_value: PathLike | None = None, identifier: str | None = None
 ) -> Path:
     """Get QDT working directory.
 
     Args:
         specific_value (PathLike, optional): a specific path to use. If set it's \
             expanded and returned. Defaults to None.
-        identifier (str, optional): used to make the folder unique. If not set, \
-            'default' (sure, not so unique...) is used. Defaults to "default".
+        identifier (str, optional): used to make the folder unique. Defaults to None.
 
     Returns:
         Path: path to the QDT working directory
     """
     if specific_value:
-        logger.info(f"QDT working folder - Using the specified value: {specific_value}")
+        logger.debug(
+            f"QDT working folder - Using the specified value: {specific_value}"
+        )
         return Path(expandvars(expanduser(specific_value)))
     elif qdt_local_working_folder := getenv("QDT_LOCAL_WORK_DIR"):
-        logger.info(
+        logger.debug(
             "QDT working folder - Using value specified as environment variable: "
             f"{qdt_local_working_folder}"
         )
         return Path(expandvars(expanduser(qdt_local_working_folder)))
     else:
-        if identifier:
-            logger.info(
+        if identifier is not None:
+            logger.debug(
                 f"QDT working folder - Using default path '{DEFAULT_QDT_WORKING_FOLDER}' "
                 f"with custom identifier '{identifier}'"
             )
-        else:
-            logger.info(
-                f"QDT working folder - Using default path: {DEFAULT_QDT_WORKING_FOLDER}"
-            )
-        return Path(
-            expandvars(
-                expanduser(
-                    getenv(
-                        "QDT_LOCAL_WORK_DIR",
-                        f"~/.cache/qgis-deployment-toolbelt/{identifier}",
-                    ),
+            return Path(
+                expandvars(
+                    expanduser(
+                        getenv(
+                            "QDT_LOCAL_WORK_DIR",
+                            DEFAULT_QDT_WORKING_FOLDER.joinpath(identifier),
+                        ),
+                    )
                 )
             )
-        )
+        else:
+            logger.debug(
+                f"QDT working folder - Using default path: {DEFAULT_QDT_WORKING_FOLDER}"
+            )
+            return Path(
+                expandvars(
+                    expanduser(getenv("QDT_LOCAL_WORK_DIR", DEFAULT_QDT_WORKING_FOLDER))
+                )
+            )
 
 
 # #############################################################################
@@ -94,7 +100,7 @@ class OSConfiguration:
 
     name_python: str
     names_alter: list = None
-    profiles_path: Path = getenv("QGIS_CUSTOM_CONFIG_PATH")
+    profiles_path: Path | None = getenv("QGIS_CUSTOM_CONFIG_PATH")
     qgis_bin_exe_path: Path = None
     shortcut_extension: str = None
     shortcut_forbidden_chars: tuple[str] = None

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -13,6 +13,7 @@
 
 # Standard library
 import logging
+from os import getenv
 from pathlib import Path
 from sys import platform as opersys
 
@@ -53,12 +54,12 @@ class GenericJob:
                 "Creating it to properly run the job."
             )
             self.qdt_working_folder.mkdir(parents=True, exist_ok=True)
-        logger.debug(f"Working folder: {self.qdt_working_folder}")
+        logger.debug(f"QDT working folder: {self.qdt_working_folder}")
 
         self.qdt_downloaded_repositories = self.qdt_working_folder.joinpath(
-            "repositories"
+            f"repositories/{getenv('QDT_TMP_RUNNING_SCENARIO_ID', 'default')}"
         )
-        self.qdt_plugins_folder = self.qdt_working_folder.parent.joinpath("plugins")
+        self.qdt_plugins_folder = self.qdt_working_folder.joinpath("plugins")
 
         # destination profiles folder
         self.qgis_profiles_path: Path = Path(OS_CONFIG.get(opersys).profiles_path)
@@ -70,35 +71,40 @@ class GenericJob:
             self.qgis_profiles_path.mkdir(parents=True)
         logger.debug(f"Installed QGIS profiles folder: {self.qgis_profiles_path}")
 
-    def list_downloaded_profiles(self) -> tuple[QdtProfile]:
+    def list_downloaded_profiles(self) -> tuple[QdtProfile] | None:
         """List downloaded QGIS profiles, i.e. a profile's folder located into the QDT
             working folder.
-            Typically: `~/.cache/qgis-deployment-toolbelt/geotribu` or
-            `%USERPROFILE%/.cache/qgis-deployment-toolbelt/geotribu`).
+            Typically: `~/.cache/qgis-deployment-toolbelt/repositories/geotribu` or
+            `%USERPROFILE%/.cache/qgis-deployment-toolbelt/repositories/geotribu`).
 
         Returns:
-            tuple[QdtProfile]: tuple of profiles objects
+            tuple[QdtProfile] | None: tuple of profiles objects or None if no profile
+                folder listed
         """
         return self.filter_profiles_folder(
             start_parent_folder=self.qdt_downloaded_repositories
         )
 
-    def list_installed_profiles(self) -> tuple[QdtProfile]:
+    def list_installed_profiles(self) -> tuple[QdtProfile] | None:
         """List installed QGIS profiles, i.e. a profile's folder located into the QGIS
             profiles path and so accessible to the end-user through the QGIS interface.
             Typically: `~/.local/share/QGIS/QGIS3/profiles/geotribu` or
             `%APPDATA%/QGIS/QGIS3/profiles/geotribu`).
 
         Returns:
-            tuple[QdtProfile]: tuple of profiles objects
+            tuple[QdtProfile] | None: tuple of profiles objects or Non if no profile is
+                installed in QGIS3/profiles
         """
         return self.filter_profiles_folder(start_parent_folder=self.qgis_profiles_path)
 
-    def filter_profiles_folder(self, start_parent_folder: Path) -> tuple[QdtProfile]:
+    def filter_profiles_folder(
+        self, start_parent_folder: Path
+    ) -> tuple[QdtProfile] | None:
         """Parse a folder structure to filter on QGIS profiles folders.
 
         Returns:
-            tuple[QdtProfile]: tuple of profiles objects
+            tuple[QdtProfile] | None: tuple of profiles objects or Non if no profile
+                folder found
         """
         # first, try to get folders containing a profile.json
         qgis_profiles_folder = [

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -45,7 +45,7 @@ class GenericJob:
 
     def __init__(self) -> None:
         """Object instanciation."""
-        # local QDT folder
+        # local QDT folders
         self.qdt_working_folder = get_qdt_working_directory()
         if not self.qdt_working_folder.exists():
             logger.info(
@@ -54,6 +54,11 @@ class GenericJob:
             )
             self.qdt_working_folder.mkdir(parents=True, exist_ok=True)
         logger.debug(f"Working folder: {self.qdt_working_folder}")
+
+        self.qdt_downloaded_repositories = self.qdt_working_folder.joinpath(
+            "repositories"
+        )
+        self.qdt_plugins_folder = self.qdt_working_folder.parent.joinpath("plugins")
 
         # destination profiles folder
         self.qgis_profiles_path: Path = Path(OS_CONFIG.get(opersys).profiles_path)
@@ -74,7 +79,9 @@ class GenericJob:
         Returns:
             tuple[QdtProfile]: tuple of profiles objects
         """
-        return self.filter_profiles_folder(start_parent_folder=self.qdt_working_folder)
+        return self.filter_profiles_folder(
+            start_parent_folder=self.qdt_downloaded_repositories
+        )
 
     def list_installed_profiles(self) -> tuple[QdtProfile]:
         """List installed QGIS profiles, i.e. a profile's folder located into the QGIS

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -70,7 +70,6 @@ class JobPluginsDownloader(GenericJob):
         self.options: dict = self.validate_options(options)
 
         # where QDT downloads plugins
-        self.qdt_plugins_folder = self.qdt_working_folder.parent / "plugins"
         self.qdt_plugins_folder.mkdir(exist_ok=True, parents=True)
         logger.info(f"QDT plugins folder: {self.qdt_plugins_folder}")
 
@@ -78,7 +77,7 @@ class JobPluginsDownloader(GenericJob):
         """Execute job logic."""
         # list plugins through different profiles
         qdt_referenced_plugins = self.list_referenced_plugins(
-            parent_folder=self.qdt_working_folder
+            parent_folder=self.qdt_downloaded_repositories
         )
         if not len(qdt_referenced_plugins):
             logger.info(

--- a/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
@@ -73,21 +73,16 @@ class JobPluginsSynchronizer(GenericJob):
         self.options: dict = self.validate_options(options)
 
         # where QDT downloads plugins
-        self.qdt_plugins_folder = self.qdt_working_folder.parent / "plugins"
         self.qdt_plugins_folder.mkdir(exist_ok=True, parents=True)
         logger.info(f"QDT plugins folder: {self.qdt_plugins_folder}")
-
-        logger.debug(
-            "Using plugins listed into profile.json files found into profiles "
-            f"already installed under the QGIS3 user data: {self.qgis_profiles_path.resolve()}"
-        )
 
         # which profile.json file to use
         if self.options.get("profile_ref") == "installed":
             self.profiles_path = self.qgis_profiles_path
             logger.debug(
                 "Using plugins listed into profile.json files found into profiles "
-                f"already installed under the QGIS3 user data: {self.profiles_path.resolve()}"
+                "already installed under the QGIS3 user folder: "
+                f"{self.profiles_path.resolve()}"
             )
         else:
             self.profiles_path = self.qdt_working_folder

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -104,6 +104,13 @@ class JobProfilesDownloader(GenericJob):
         super().__init__()
         self.options: dict = self.validate_options(options)
 
+        # where QDT downloads remote repositories
+        self.qdt_plugins_folder.mkdir(exist_ok=True, parents=True)
+        logger.info(
+            "QDT folder where remote repositories will be downloaded: "
+            f"{self.qdt_downloaded_repositories}"
+        )
+
     def run(self) -> None:
         """Execute job logic."""
         # download or refresh
@@ -129,15 +136,17 @@ class JobProfilesDownloader(GenericJob):
                     source_repository_url=self.options.get("source"),
                     branch_to_use=self.options.get("branch", "master"),
                 )
-                downloader.download(destination_local_path=self.qdt_working_folder)
-            elif self.options.get("protocol") == "git_local" or self.options.get(
-                "source"
-            ).startswith("file://"):
+                downloader.download(
+                    destination_local_path=self.qdt_downloaded_repositories
+                )
+            elif self.options.get("source").startswith("file://"):
                 downloader = LocalGitHandler(
                     source_repository_path_or_uri=self.options.get("source"),
                     branch_to_use=self.options.get("branch", "master"),
                 )
-                downloader.download(destination_local_path=self.qdt_working_folder)
+                downloader.download(
+                    destination_local_path=self.qdt_downloaded_repositories
+                )
             else:
                 logger.error(
                     f"Source type is not implemented yet: {self.options.get('source')}"

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -105,11 +105,8 @@ class JobProfilesDownloader(GenericJob):
         self.options: dict = self.validate_options(options)
 
         # where QDT downloads remote repositories
-        self.qdt_plugins_folder.mkdir(exist_ok=True, parents=True)
-        logger.info(
-            "QDT folder where remote repositories will be downloaded: "
-            f"{self.qdt_downloaded_repositories}"
-        )
+        self.qdt_downloaded_repositories.mkdir(exist_ok=True, parents=True)
+        logger.debug(f"Local repositories folder: {self.qdt_downloaded_repositories}")
 
     def run(self) -> None:
         """Execute job logic."""
@@ -136,16 +133,10 @@ class JobProfilesDownloader(GenericJob):
                     source_repository_url=self.options.get("source"),
                     branch_to_use=self.options.get("branch", "master"),
                 )
-                downloader.download(
-                    destination_local_path=self.qdt_downloaded_repositories
-                )
             elif self.options.get("source").startswith("file://"):
                 downloader = LocalGitHandler(
                     source_repository_path_or_uri=self.options.get("source"),
                     branch_to_use=self.options.get("branch", "master"),
-                )
-                downloader.download(
-                    destination_local_path=self.qdt_downloaded_repositories
                 )
             else:
                 logger.error(
@@ -163,13 +154,15 @@ class JobProfilesDownloader(GenericJob):
             downloader = HttpHandler(
                 source_repository_path_or_uri=self.options.get("source"),
             )
-            downloader.download(destination_local_path=self.qdt_working_folder)
         else:
             logger.critical(
                 f"Protocol '{self.options.get('protocol')}' is not part of supported ones: "
                 f"{self.OPTIONS_SCHEMA.get('protocol').get('possible_values')}"
             )
             raise NotImplementedError
+
+        # run download operation
+        downloader.download(destination_local_path=self.qdt_downloaded_repositories)
 
         # check of there are some profiles folders within the downloaded folder
         profiles_folders = self.list_downloaded_profiles()

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -17,6 +17,8 @@ import logging
 from os import environ
 from pathlib import Path
 
+# project
+from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.jobs.job_environment_variables import (
     JobEnvironmentVariables,
 )
@@ -91,7 +93,7 @@ class JobsOrchestrator:
             if job.ID == job_id:
                 return job
 
-    def init_job_class_from_id(self, job_id: str, options: dict) -> object:
+    def init_job_class_from_id(self, job_id: str, options: dict) -> GenericJob:
         """Get job class from id and instanciate it with options.
 
         :param str job_id: job identifier (i.e. "qprofiles-manager")

--- a/qgis_deployment_toolbelt/utils/journalizer.py
+++ b/qgis_deployment_toolbelt/utils/journalizer.py
@@ -91,7 +91,7 @@ def configure_logger(verbosity: int = 1, logfile: Path = None):
                 f"Logs folder set with QDT_LOGS_DIR environment variable: {logs_folder}"
             )
         else:
-            logs_folder = get_qdt_working_directory().parent / "logs"
+            logs_folder = get_qdt_working_directory().joinpath("logs")
             logger.debug(
                 "Logs folder specified in QDT_LOGS_DIR environment variable "
                 f"{getenv('QDT_LOGS_DIR')} can't be used (see logs above). Fallback on "
@@ -110,6 +110,7 @@ def configure_logger(verbosity: int = 1, logfile: Path = None):
             maxBytes=3000000,
             mode="a",
         )
+
         # force new file by execution
         if logs_filepath.is_file():
             log_file_handler.doRollover()
@@ -148,3 +149,18 @@ def headers():
         logger.debug(f"Network proxies detected: {proxies_settings}")
     else:
         logger.debug("No network proxies detected")
+
+
+def get_logger_filepath() -> Path | None:
+    """Retrieve log filepath within logger handlers.
+
+    Returns:
+        Path | None: path to the logfile or None if no handler has baseFilename attr.
+    """
+    if logger.root.hasHandlers():
+        for handler in logger.root.handlers:
+            if hasattr(handler, "baseFilename"):
+                return Path(handler.baseFilename)
+
+    logger.warning("No file found in ay log handlers.")
+    return None


### PR DESCRIPTION
This PR aims to improve how QDT organizes its proper local folder, moving downloaded profiles (repositores) into a specific folder.

