### PR TITLE
feature: add util to get ProxyHandler and cache some recurring functions

### DIFF
--- a/qgis_deployment_toolbelt/utils/proxies.py
+++ b/qgis_deployment_toolbelt/utils/proxies.py
@@ -12,8 +12,9 @@
 
 # Standard library
 import logging
+from functools import lru_cache
 from os import environ
-from urllib.request import getproxies
+from urllib.request import OpenerDirector, ProxyHandler, build_opener, getproxies
 
 # package
 from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
@@ -29,8 +30,25 @@ logger = logging.getLogger(__name__)
 # #############################################################################
 # ########## Functions #############
 # ##################################
+@lru_cache
+def get_proxy_handler() -> OpenerDirector:
+    """Return URL opener with or without proxy handler.
+
+    Returns:
+        OpenerDirector: request handler supporting proxy settings
+    """
+    # Handle network proxy
+    if get_proxy_settings() is not None:
+        proxy_handler = ProxyHandler(get_proxy_settings())  # Create a proxy handler
+        opener = build_opener(proxy_handler)  # Create an opener that will use the proxy
+    else:
+        proxy_handler = ProxyHandler()  # Create a proxy handler
+        opener = build_opener(proxy_handler)  # Create an opener that will use the proxy
+
+    return opener
 
 
+@lru_cache
 def get_proxy_settings() -> dict | None:
     """Retrieves network proxy settings from operating system configuration or
     environment variables.

--- a/tests/test_utils_proxies.py
+++ b/tests/test_utils_proxies.py
@@ -31,6 +31,7 @@ class TestUtilsNetworkProxies(unittest.TestCase):
         self.assertIsNone(get_proxy_settings())
 
         # using generic - only http
+        get_proxy_settings.cache_clear()
         environ["HTTP_PROXY"] = "http://proxy.example.com:3128"
         self.assertIsInstance(get_proxy_settings(), dict)
         self.assertEqual(
@@ -41,6 +42,7 @@ class TestUtilsNetworkProxies(unittest.TestCase):
         environ.pop("HTTP_PROXY")  # clean up
 
         # using generic - only https
+        get_proxy_settings.cache_clear()
         environ["HTTPS_PROXY"] = "https://proxy.example.com:3128"
         self.assertIsInstance(get_proxy_settings(), dict)
         self.assertEqual(
@@ -51,6 +53,7 @@ class TestUtilsNetworkProxies(unittest.TestCase):
         environ.pop("HTTPS_PROXY")  # clean up
 
         # using generic - both http and https
+        get_proxy_settings.cache_clear()
         environ["HTTP_PROXY"] = "http://proxy.example.com:3128"
         environ["HTTPS_PROXY"] = "https://proxy.example.com:3128"
         self.assertIsInstance(get_proxy_settings(), dict)
@@ -65,6 +68,7 @@ class TestUtilsNetworkProxies(unittest.TestCase):
         environ.pop("HTTPS_PROXY")  # clean up
 
         # using custom QDT
+        get_proxy_settings.cache_clear()
         environ["QDT_PROXY_HTTP"] = "http://user:p8ùX45@proxy.example.com:3128"
         self.assertIsInstance(get_proxy_settings(), dict)
         self.assertEqual(


### PR DESCRIPTION
Extracted evolution from #294 which add a convenient `get_proxy_handler` function and cache recurring functions.