### PR TITLE
feature: use proxy handler in file downloader

### DIFF
--- a/qgis_deployment_toolbelt/utils/file_downloader.py
+++ b/qgis_deployment_toolbelt/utils/file_downloader.py
@@ -9,11 +9,11 @@
 import logging
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.request import ProxyHandler, Request, build_opener, install_opener, urlopen
+from urllib.request import Request
 
 # package
 from qgis_deployment_toolbelt.__about__ import __title_clean__, __version__
-from qgis_deployment_toolbelt.utils.proxies import get_proxy_settings
+from qgis_deployment_toolbelt.utils.proxies import get_proxy_handler
 
 # ############################################################################
 # ########## GLOBALS #############
@@ -32,7 +32,7 @@ def download_remote_file_to_local(
     remote_url_to_download: str,
     local_file_path: Path,
     user_agent: str = f"{__title_clean__}/{__version__}",
-    content_type: str = None,
+    content_type: str | None = None,
     chunk_size: int = 8192,
 ) -> Path:
     """Check if the local index file exists. If not, download the search index from \
@@ -49,11 +49,6 @@ def download_remote_file_to_local(
     Returns:
         Path: path to the local file (should be the same as local_file_path)
     """
-    # Handle network proxy
-    proxy_handler = ProxyHandler(get_proxy_settings())  # Create a proxy handler
-    opener = build_opener(proxy_handler)  # Create an opener that will use the proxy
-    install_opener(opener)  # Install the opener
-
     # check if file exists
     if local_file_path.exists():
         logger.warning(f"{local_file_path} already exists. It's about to be replaced.")
@@ -71,7 +66,7 @@ def download_remote_file_to_local(
     custom_request = Request(url=remote_url_to_download, headers=headers)
 
     try:
-        with urlopen(custom_request) as response, local_file_path.open(
+        with get_proxy_handler().open(custom_request) as response, local_file_path.open(
             mode="wb"
         ) as buffile:
             while True:


### PR DESCRIPTION
Extracted evolution from https://github.com/Guts/qgis-deployment-cli/pull/294 and following #358 to use the `get_proxy_handler` in file downloader.