### PR TITLE
security: bump pillow to 10.2 to fix CVE-2022-22817

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,6 +2,6 @@
 # --------------------
 
 GitPython>=3.1,<3.2
-Pillow>=10.0.1,<10.2
+Pillow>=10.2,<10.3
 pytest-cov>=4,<4.2
 validators>=0.20,<0.23


### PR DESCRIPTION
Not a real problme since it's just a test dependency. Still here comes the fix for https://github.com/Guts/qgis-deployment-cli/security/dependabot/2

> Pillow through 10.1.0 allows PIL.ImageMath.eval Arbitrary Code Execution via the environment parameter, a different vulnerability than CVE-2022-22817 (which was about the expression parameter).