### PR TITLE
fix: change refs to menu_from_projects to match new versioning scheme

### DIFF
--- a/examples/profiles/Viewer Mode/profile.json
+++ b/examples/profiles/Viewer Mode/profile.json
@@ -15,7 +15,7 @@
       "folder_name": "menu_from_project",
       "official_repository": true,
       "plugin_id": 43,
-      "version": "v2.0.8"
+      "version": "2.1.0"
     },
     {
       "name": "qNote",

--- a/qgis_deployment_toolbelt/plugins/plugin.py
+++ b/qgis_deployment_toolbelt/plugins/plugin.py
@@ -347,7 +347,7 @@ if __name__ == "__main__":
         "name": "french_locator_filter",
         "version": "1.0.4",
         "url": "https://plugins.qgis.org/plugins/french_locator_filter/version/1.0.4/download/",
-        "type": "remote",
+        "location": "remote",
     }
 
     plugin_obj_one: QgisPlugin = QgisPlugin.from_dict(sample_plugin_complete)
@@ -380,9 +380,9 @@ if __name__ == "__main__":
 
     sample_plugin_different_name = {
         "name": "Layers menu from project",
-        "version": "v2.0.6",
-        "url": "https://plugins.qgis.org/plugins/menu_from_project/version/2.0.6/download/",
-        "type": "remote",
+        "version": "2.1.0",
+        "url": "https://plugins.qgis.org/plugins/menu_from_project/version/2.1.0/download/",
+        "location": "remote",
         "plugin_id": 1846,
     }
 

--- a/tests/fixtures/profiles/good_profile_complete.json
+++ b/tests/fixtures/profiles/good_profile_complete.json
@@ -15,22 +15,21 @@
       "name": "french_locator_filter",
       "version": "1.0.4",
       "url": "https://plugins.qgis.org/plugins/french_locator_filter/version/1.0.4/download/",
-      "type": "remote",
+      "location": "remote",
       "plugin_id": 1846
     },
     {
       "name": "pg_metadata",
       "version": "1.2.1",
       "url": "https://plugins.qgis.org/plugins/pg_metadata/version/1.2.1/download/",
-      "type": "remote"
+      "location": "remote"
     },
     {
       "name": "Layers menu from project",
-      "version": "v2.0.6",
+      "version": "2.1.0",
       "official_repository": true,
       "plugin_id": 0,
-      "url": "https://plugins.qgis.org/plugins/menu_from_project/version/2.0.6/download/",
-      "type": "remote"
+      "location": "remote"
     },
     {
       "name": "Geotuileur",

--- a/tests/fixtures/profiles/good_sample_profile.json
+++ b/tests/fixtures/profiles/good_sample_profile.json
@@ -15,7 +15,7 @@
             "folder_name": "menu_from_project",
             "official_repository": true,
             "plugin_id": 43,
-            "version": "v2.0.6"
+            "version": "2.1.0"
         },
         {
             "name": "QuickOSM",

--- a/tests/test_qplugin_object.py
+++ b/tests/test_qplugin_object.py
@@ -79,7 +79,7 @@ class TestQgisPluginObject(unittest.TestCase):
             "name": "french_locator_filter",
             "version": "1.0.4",
             "url": "https://plugins.qgis.org/plugins/french_locator_filter/version/1.0.4/download/",
-            "type": "remote",
+            "location": "remote",
         }
 
         plugin_obj_one: QgisPlugin = QgisPlugin.from_dict(sample_plugin_complete)
@@ -121,9 +121,9 @@ class TestQgisPluginObject(unittest.TestCase):
         # plugin as dict
         sample_plugin_complex = {
             "name": "Layers menu from project",
-            "version": "2.0.6",
-            "url": "https://plugins.qgis.org/plugins/menu_from_project/version/2.0.6/download/",
-            "type": "remote",
+            "version": "2.1.0",
+            "url": "https://plugins.qgis.org/plugins/menu_from_project/version/2.1.0/download/",
+            "location": "remote",
             "plugin_id": 1846,
         }
         # plugin as object


### PR DESCRIPTION
The plugin changed its versioning scheme on plugins repository without any warning so it breaks out the referring profiles (examples, tests...).

This PR fixes that.

cc @xcaeag