### PR TITLE
Refacto: split profiles sync job

### DIFF
--- a/docs/jobs/index.md
+++ b/docs/jobs/index.md
@@ -9,7 +9,8 @@ glob:
 environment_variables.md
 plugins_downloader.md
 plugins_synchronizer.md
-profiles_manager.md
+profiles_downloader.md
+profiles_synchronizer.md
 shortcuts_manager.md
 splash_screen_manager.md
 *

--- a/docs/jobs/profiles_downloader.md
+++ b/docs/jobs/profiles_downloader.md
@@ -1,15 +1,6 @@
-# Profiles manager
+# Profiles Downloader
 
-```{error}
-Since version 0.31.0, this job has been split into 2 jobs:
-
-- [profiles-downloader](./profiles_downloader.md)
-- [profiles-synchronizer](./profiles_synchronizer.md)
-
-Please update your scenario files.
-```
-
-This job synchronize local profiles from remote storage (git for now).
+This job downloads remote profiles through different protocols to the local QDT working folder.
 
 ----
 
@@ -20,44 +11,40 @@ Sample job configurations.
 ### **Remote** HTTP repository
 
 ```yaml
-- name: Synchronize profiles from local git repository
-  uses: qprofiles-manager
+- name: Download profiles from remote HTTP server
+  uses: qprofiles-downloader
   with:
-    action: download
     branch: main
     protocol: http
     source: https://organization.intra/qgis/qdt/
-    sync_mode: only_new_version
 ```
 
 :::{note}
 If you use the HTTP procotol, a `qdt-files.json` must be downloadable at the URL source. Typically: `https://organization.intra/qgis/qdt/qdt-files.json`.
+
+See this guide on [how to generate the qdt-files.json](../usage/profile.md#generate-the-qdt-filesjson-index-file).
 :::
 
-### Public **remote** git repository in **overwrite** mode
+### Public **remote** git repository
 
 ```yaml
-- name: Synchronize profiles from remote git repository
-  uses: qprofiles-manager
+- name: Download profiles from remote Git server
+  uses: qprofiles-downloader
   with:
-    action: download
     branch: main
     protocol: git_remote
     source: https://github.com/geotribu/profils-qgis.git
-    sync_mode: overwrite
 ```
 
 ### **Local** git repository
 
 ```yaml
-- name: Synchronize profiles from local git repository
-  uses: qprofiles-manager
+- name: Download profiles from local Git repository
+  uses: qprofiles-downloader
   with:
-    action: download
     branch: main
     protocol: git_local
     source: file:///home/jmo/Git/Geotribu/profils-qgis
-    sync_mode: only_new_version
 ```
 
 ----
@@ -97,14 +84,3 @@ Must start with:
 - `file://`: for local disk or network
 - `git://` (_recomended_): for git repositories
 - `https://`: for profiles stored into git repositories accessible through HTTP or profiles downloadable through an HTTP server
-
-### sync_mode
-
-Synchronization mode to apply with profiles.
-
-Possible_values:
-
-- `only_missing` (_default_): only install profiles that does not exist locally
-- `only_different_version`: only install profiles that does not exist locally and update those with a different version number (lesser or upper)
-- `only_new_version`: only install profiles that does not exist locally and update those with a lesser version number
-- `overwrite`: systematically overwrite local profiles

--- a/docs/jobs/profiles_synchronizer.md
+++ b/docs/jobs/profiles_synchronizer.md
@@ -1,0 +1,53 @@
+# Profiles Synchronizer
+
+This job synchronizes installed profiles (those stored in QGIS profiles folder) from the downloaded ones (those stored in QDT local folder).
+
+----
+
+## Use it
+
+Sample job configurations.
+
+### Update or install profiles only with a newer version number
+
+```yaml
+- name: Synchronize installed profiles from downloaded ones
+  uses: qprofiles-synchronizer
+  with:
+    sync_mode: only_new_version
+```
+
+### Systematically overwrite installed profile with downloaded one
+
+```yaml
+- name: Synchronize installed profiles from downloaded ones
+  uses: qprofiles-synchronizer
+  with:
+    sync_mode: overwrite
+```
+
+
+----
+
+## Vocabulary
+
+### Profiles states
+
+- `remote`: a profile stored outside the end-user computer, on a git repository, an HTTP server or a LAN drive. Typically: `https://gitlab.com/Oslandia/qgis/profils_qgis_fr_2022.git`.
+- `downloaded`: a profile downloaded into the QDT local working folder. Typically: `~/.cache/qgis-deployment-toolbelt/Oslandia/`.
+- `installed`: a profile's folder located into the QGIS profiles folder and so accessible to the end-user through the QGIS interface. Typically: `~/.local/share/QGIS/QGIS3/profiles/default` or `%APPDATA%/QGIS/QGIS3/profiles/default`
+
+----
+
+## Options
+
+### sync_mode
+
+Synchronization mode to apply with profiles.
+
+Possible_values:
+
+- `only_missing` (_default_): only install profiles that does not exist locally
+- `only_different_version`: only install profiles that does not exist locally and update those with a different version number (lesser or upper)
+- `only_new_version`: only install profiles that does not exist locally and update those with a lesser version number
+- `overwrite`: systematically overwrite local profiles

--- a/docs/schemas/profile/qgis_plugin.json
+++ b/docs/schemas/profile/qgis_plugin.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/qgis_plugin.json",
-    "$comment": "A QGIS profile described in a JSON file.",
+    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_plugin.json",
+    "$comment": "A QGIS plugin described in a JSON file.",
     "type": "object",
     "properties": {
         "folder_name": {

--- a/docs/schemas/profile/qgis_profile.json
+++ b/docs/schemas/profile/qgis_profile.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/qgis_profile.json",
+    "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/profile/qgis_profile.json",
     "$comment": "A QGIS profile described in a JSON file.",
     "type": "object",
     "properties": {

--- a/docs/schemas/scenario/jobs/generic.json
+++ b/docs/schemas/scenario/jobs/generic.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/generic.json",
+  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/jobs/generic.json",
   "description": "Definition of a job, i.e. a logic execution which can be ran during a step.",
   "title": "Steps",
   "type": "array",
@@ -26,9 +26,14 @@
           "manage-env-vars",
           "qplugins-downloader",
           "qplugins-synchronizer",
+          "qprofiles-downloader",
+          "qprofiles-synchronizer",
           "qprofiles-manager",
           "shortcuts-manager",
           "splash-screen-manager"
+        ],
+        "deprecated": [
+          "qprofiles-manager"
         ]
       },
       "with": {

--- a/docs/schemas/scenario/jobs/manage-env-vars.json
+++ b/docs/schemas/scenario/jobs/manage-env-vars.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/manage-env-vars.json",
+  "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/manage-env-vars.json",
   "description": "Job in charge of setting/updating/removing environment variables on target computer.",
   "title": "Environment variables manager.",
   "type": "array",
@@ -10,7 +10,10 @@
       "action": {
         "default": "add",
         "description": "Tell the job what to do with the environment variable.",
-        "enum": ["add", "remove"],
+        "enum": [
+          "add",
+          "remove"
+        ],
         "type": "string"
       },
       "name": {
@@ -20,16 +23,27 @@
       "scope": {
         "default": "user",
         "description": "Level of the environment variable.",
-        "enum": ["user", "system"],
+        "enum": [
+          "user",
+          "system"
+        ],
         "type": "string"
       },
       "value": {
         "description": "Value to set to the environment variable.",
-        "type": ["boolean", "string"]
+        "type": [
+          "boolean",
+          "string"
+        ]
       },
       "value_type": {
         "description": "Value type to avoid ambiguity when interpreting it.",
-        "enum": ["bool", "path", "str", "url"],
+        "enum": [
+          "bool",
+          "path",
+          "str",
+          "url"
+        ],
         "type": "string"
       }
     },
@@ -44,10 +58,14 @@
           }
         },
         "then": {
-          "required": ["value"]
+          "required": [
+            "value"
+          ]
         }
       }
     ],
-    "required": ["name"]
+    "required": [
+      "name"
+    ]
   }
 }

--- a/docs/schemas/scenario/jobs/qplugins-downloader.json
+++ b/docs/schemas/scenario/jobs/qplugins-downloader.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/qplugins-downloader.json",
+    "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/qplugins-downloader.json",
     "description": "Download plugins into QDT local folder.",
     "title": "QPlugins Downloader.",
     "type": "object",

--- a/docs/schemas/scenario/jobs/qplugins-synchronizer.json
+++ b/docs/schemas/scenario/jobs/qplugins-synchronizer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/qplugins-synchronizer.json",
+    "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/qplugins-synchronizer.json",
     "description": "synchronize plugins between those stored locally (typically downloaded by the Plugins Downloader job) and the installed plugins.",
     "title": "QPlugins Synchronizer.",
     "type": "object",

--- a/docs/schemas/scenario/jobs/qprofiles-downloader.json
+++ b/docs/schemas/scenario/jobs/qprofiles-downloader.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/jobs/qprofiles-downloader.json",
+    "description": "Job to download remote profiles to local QDT working folder.",
+    "title": "QProfiles Downloader",
+    "type": "object",
+    "properties": {
+        "branch": {
+            "default": "master",
+            "description": "Name of the branch to use when working with a git repository.",
+            "type": "string"
+        },
+        "protocol": {
+            "description": "Set which protocol to use for downloading profiles.",
+            "enum": [
+                "http",
+                "git_local",
+                "git_remote"
+            ],
+            "deprecated": [
+                "git"
+            ],
+            "type": "string"
+        },
+        "source": {
+            "description": "Location of profiles. Typically: 'https://github.com/Guts/qgis-deployment-cli.git' or 'https://raw.githubusercontent.com/Guts/qgis-deployment-cli/examples/'",
+            "type": "string"
+        }
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "protocol": {
+                        "const": "git_local"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "branch"
+                ]
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "protocol": {
+                        "const": "git_remote"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "branch"
+                ]
+            }
+        }
+    ]
+}

--- a/docs/schemas/scenario/jobs/qprofiles-manager.json
+++ b/docs/schemas/scenario/jobs/qprofiles-manager.json
@@ -1,9 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/qprofiles-manager.json",
-    "description": "QDT job synchronizing local working directory with remote profiles.",
-    "title": "QProfiles Synchronizer.",
+    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/jobs/qprofiles-manager.json",
+    "description": "!! DEPRECATED !! Split into 2 different jobs since version 0.31. Former description: job synchronizing local working directory with remote profiles.",
+    "title": "QProfiles Manager.",
     "type": "object",
+    "deprecated": true,
     "properties": {
         "action": {
             "default": "download",
@@ -42,7 +43,6 @@
                 "only_new_version",
                 "overwrite"
             ],
-
             "type": "string"
         }
     },

--- a/docs/schemas/scenario/jobs/qprofiles-synchronizer.json
+++ b/docs/schemas/scenario/jobs/qprofiles-synchronizer.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/jobs/qprofiles-synchronizer.json",
+    "description": "Synchronizes installed profiles (in QGIS profiles folder) from downloaded ones in QDT working folder.",
+    "title": "QProfiles Synchronizer",
+    "type": "object",
+    "properties": {
+        "sync_mode": {
+            "description": "Synchronization mode to apply with profiles.",
+            "enum": [
+                "only_different_version",
+                "only_missing",
+                "only_new_version",
+                "overwrite"
+            ],
+            "type": "string"
+        }
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "protocol": {
+                        "const": "git"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "branch"
+                ]
+            }
+        }
+    ]
+}

--- a/docs/schemas/scenario/jobs/shortcuts-manager.json
+++ b/docs/schemas/scenario/jobs/shortcuts-manager.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/shortcuts-manager.json",
+    "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/shortcuts-manager.json",
     "description": "create shortcuts in desktop and/or start menu allowing the end-user opening QGIS with a profile.",
     "title": "Shortcuts Manager.",
     "type": "object",

--- a/docs/schemas/scenario/jobs/splash-screen-manager.json
+++ b/docs/schemas/scenario/jobs/splash-screen-manager.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/jobs/splash-screen-manager.json",
+    "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/splash-screen-manager.json",
     "description": "Set your custom splash screen image.",
     "title": "Splash Screen Manager.",
     "type": "object",

--- a/docs/schemas/scenario/metadata.json
+++ b/docs/schemas/scenario/metadata.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/metadata.json",
+  "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/metadata.json",
   "description": "QGIS Deployment Toolbelt - Scenario metadata",
   "title": "Define scenario's metadata.",
   "type": "object",

--- a/docs/schemas/scenario/schema.json
+++ b/docs/schemas/scenario/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/schema.json",
+  "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/schema.json",
   "$comment": "Deploy and configure QGIS and related components (plugins, shortcuts, etc.).",
   "type": "object",
   "properties": {

--- a/docs/schemas/scenario/settings.json
+++ b/docs/schemas/scenario/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/feature/scenario-pseudo-ci/docs/schemas/settings.json",
+  "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/settings.json",
   "title": "QGIS Deployment Toolbelt - Environment variables",
   "description": "Define environment variables for the QGIS Deployment CLI execution, prefixing them with 'QDT_'. Attention, no confusion: these are the settings for the toolbelt, not for the QGIS installation.",
   "type": "object",

--- a/examples/scenarios/demo-scenario-http.qdt.yml
+++ b/examples/scenarios/demo-scenario-http.qdt.yml
@@ -13,10 +13,14 @@ settings:
 # Deployment workflow, step by step
 steps:
   - name: Download profiles from remote git repository
-    uses: qprofiles-manager
+    uses: qprofiles-downloader
     with:
       source: https://raw.githubusercontent.com/Guts/qgis-deployment-cli/examples/
       protocol: http
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
       sync_mode: only_new_version
 
   - name: Download plugins

--- a/examples/scenarios/demo-scenario.qdt.yml
+++ b/examples/scenarios/demo-scenario.qdt.yml
@@ -18,12 +18,16 @@ settings:
 # Deployment workflow, step by step
 steps:
   - name: Download profiles from remote git repository
-    uses: qprofiles-manager
+    uses: qprofiles-downloader
     with:
       source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
-      sync_mode: overwrite
       branch: main
+
+  - name: Download profiles from remote git repository
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: overwrite
 
   - name: Download plugins
     uses: qplugins-downloader

--- a/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
@@ -1,0 +1,165 @@
+#! python3  # noqa: E265
+
+"""
+    Download remote QGIS profiles to QDT working folder.
+
+    Author: Julien Moura (https://github.com/guts)
+"""
+
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import logging
+
+# package
+from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.profiles import LocalGitHandler, RemoteGitHandler
+from qgis_deployment_toolbelt.profiles.remote_http_handler import HttpHandler
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class JobProfilesDownloader(GenericJob):
+    """
+    Job to download remote profiles and set them.
+    """
+
+    ID: str = "qprofiles-downloader"
+    OPTIONS_SCHEMA: dict = {
+        "branch": {
+            "type": str,
+            "required": False,
+            "default": "master",
+            "possible_values": None,
+            "condition": None,
+        },
+        "local_destination": {
+            "type": str,
+            "required": False,
+            "default": ".cache/qgis-deployment-toolbelt/profiles",
+            "possible_values": None,
+            "condition": None,
+        },
+        "protocol": {
+            "type": str,
+            "required": True,
+            "default": "git_remote",
+            "possible_values": ("git", "git_local", "git_remote", "http"),
+            "condition": "in",
+        },
+        "source": {
+            "type": str,
+            "required": True,
+            "default": None,
+            "possible_values": ("https://", "http://", "git://", "file://"),
+            "condition": "startswith",
+        },
+    }
+    PROFILES_NAMES_DOWNLOADED: list = []
+
+    def __init__(self, options: dict) -> None:
+        """Instantiate the class.
+
+        Args:
+            options (List[dict]): list of dictionary with environment variables to set
+            or remove.
+        """
+        super().__init__()
+        self.options: dict = self.validate_options(options)
+
+        # where QDT downloads remote repositories
+        self.qdt_downloaded_repositories.mkdir(exist_ok=True, parents=True)
+        logger.debug(f"Local repositories folder: {self.qdt_downloaded_repositories}")
+
+    def run(self) -> None:
+        """Execute job logic."""
+        # download or refresh
+        if self.options.get("action", "download") != "download":
+            raise NotImplementedError
+
+        # prepare remote source
+        if self.options.get("protocol") in ("git", "git_local", "git_remote"):
+            if self.options.get("protocol") == "git":
+                logger.warning(
+                    DeprecationWarning(
+                        "'git' protocol has been split into 2 more explicit: 'git_local' "
+                        "(for git repositories accessible directly through file system "
+                        "and 'git_remote' (for repositories accessible network request "
+                        "to a remote git server through HTTP). "
+                        "Please update your scenario consequently."
+                    )
+                )
+            if self.options.get("protocol") == "git_remote" or self.options.get(
+                "source"
+            ).startswith(("git://", "http://", "https://")):
+                downloader = RemoteGitHandler(
+                    source_repository_url=self.options.get("source"),
+                    branch_to_use=self.options.get("branch", "master"),
+                )
+            elif self.options.get("source").startswith("file://"):
+                downloader = LocalGitHandler(
+                    source_repository_path_or_uri=self.options.get("source"),
+                    branch_to_use=self.options.get("branch", "master"),
+                )
+            else:
+                logger.error(
+                    f"Source type is not implemented yet: {self.options.get('source')}"
+                    f"for '{self.options.get('protocol')}' protocol"
+                )
+                raise NotImplementedError
+        elif self.options.get("protocol") == "http":
+            if not self.options.get("source").startswith(("http://", "https://")):
+                logger.error(
+                    f"Source type not implemented yet: {self.options.get('source')} "
+                    f"for '{self.options.get('protocol')}' protocol"
+                )
+                raise NotImplementedError
+            downloader = HttpHandler(
+                source_repository_path_or_uri=self.options.get("source"),
+            )
+        else:
+            logger.critical(
+                f"Protocol '{self.options.get('protocol')}' is not part of supported ones: "
+                f"{self.OPTIONS_SCHEMA.get('protocol').get('possible_values')}"
+            )
+            raise NotImplementedError
+
+        # run download operation
+        downloader.download(destination_local_path=self.qdt_downloaded_repositories)
+
+        # check of there are some profiles folders within the downloaded folder
+        profiles_folders = self.list_downloaded_profiles()
+        if profiles_folders is None:
+            logger.error("No QGIS profile found in the downloaded folder.")
+            return
+
+        # store downloaded profiles names
+        self.PROFILES_NAMES_DOWNLOADED = [d.name for d in profiles_folders]
+        logger.info(
+            f"{len(self.PROFILES_NAMES_DOWNLOADED)} downloaded profiles: "
+            f"{', '.join(self.PROFILES_NAMES_DOWNLOADED)}"
+        )
+
+        logger.debug(f"Job {self.ID} ran successfully.")
+
+
+# #############################################################################
+# ##### Stand alone program ########
+# ##################################
+
+if __name__ == "__main__":
+    """Standalone execution."""
+    pass

--- a/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
@@ -46,13 +46,6 @@ class JobProfilesDownloader(GenericJob):
             "possible_values": None,
             "condition": None,
         },
-        "local_destination": {
-            "type": str,
-            "required": False,
-            "default": ".cache/qgis-deployment-toolbelt/profiles",
-            "possible_values": None,
-            "condition": None,
-        },
         "protocol": {
             "type": str,
             "required": True,
@@ -86,10 +79,6 @@ class JobProfilesDownloader(GenericJob):
 
     def run(self) -> None:
         """Execute job logic."""
-        # download or refresh
-        if self.options.get("action", "download") != "download":
-            raise NotImplementedError
-
         # prepare remote source
         if self.options.get("protocol") in ("git", "git_local", "git_remote"):
             if self.options.get("protocol") == "git":

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -1,7 +1,8 @@
 #! python3  # noqa: E265
 
 """
-    Download remote QGIS profiles to local.
+    Synchronize profiles between downloaded (in QDT working folder) and installed
+        profiles (in QGIS profiles'folder).
 
     Author: Julien Moura (https://github.com/guts)
 """
@@ -19,9 +20,7 @@ from shutil import copy2, copytree
 
 # package
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
-from qgis_deployment_toolbelt.profiles import LocalGitHandler, RemoteGitHandler
 from qgis_deployment_toolbelt.profiles.qdt_profile import QdtProfile
-from qgis_deployment_toolbelt.profiles.remote_http_handler import HttpHandler
 
 # #############################################################################
 # ########## Globals ###############
@@ -36,48 +35,14 @@ logger = logging.getLogger(__name__)
 # ##################################
 
 
-class JobProfilesDownloader(GenericJob):
+class JobProfilesSynchronizer(GenericJob):
     """
-    Job to download remote profiles and set them.
+    Job to synchronize profiles between downloaded (in QDT working folder) and installed
+        profiles (in QGIS profiles'folder).
     """
 
-    ID: str = "qprofiles-manager"
+    ID: str = "qprofiles-synchronizer"
     OPTIONS_SCHEMA: dict = {
-        "action": {
-            "type": str,
-            "required": False,
-            "default": "download",
-            "possible_values": ("download", "refresh"),
-            "condition": "in",
-        },
-        "branch": {
-            "type": str,
-            "required": False,
-            "default": "master",
-            "possible_values": None,
-            "condition": None,
-        },
-        "local_destination": {
-            "type": str,
-            "required": False,
-            "default": ".cache/qgis-deployment-toolbelt/profiles",
-            "possible_values": None,
-            "condition": None,
-        },
-        "protocol": {
-            "type": str,
-            "required": True,
-            "default": "git_remote",
-            "possible_values": ("git", "git_local", "git_remote", "http"),
-            "condition": "in",
-        },
-        "source": {
-            "type": str,
-            "required": True,
-            "default": None,
-            "possible_values": ("https://", "http://", "git://", "file://"),
-            "condition": "startswith",
-        },
         "sync_mode": {
             "type": str,
             "required": False,
@@ -110,60 +75,6 @@ class JobProfilesDownloader(GenericJob):
 
     def run(self) -> None:
         """Execute job logic."""
-        # download or refresh
-        if self.options.get("action", "download") != "download":
-            raise NotImplementedError
-
-        # prepare remote source
-        if self.options.get("protocol") in ("git", "git_local", "git_remote"):
-            if self.options.get("protocol") == "git":
-                logger.warning(
-                    DeprecationWarning(
-                        "'git' protocol has been split into 2 more explicit: 'git_local' "
-                        "(for git repositories accessible directly through file system "
-                        "and 'git_remote' (for repositories accessible network request "
-                        "to a remote git server through HTTP). "
-                        "Please update your scenario consequently."
-                    )
-                )
-            if self.options.get("protocol") == "git_remote" or self.options.get(
-                "source"
-            ).startswith(("git://", "http://", "https://")):
-                downloader = RemoteGitHandler(
-                    source_repository_url=self.options.get("source"),
-                    branch_to_use=self.options.get("branch", "master"),
-                )
-            elif self.options.get("source").startswith("file://"):
-                downloader = LocalGitHandler(
-                    source_repository_path_or_uri=self.options.get("source"),
-                    branch_to_use=self.options.get("branch", "master"),
-                )
-            else:
-                logger.error(
-                    f"Source type is not implemented yet: {self.options.get('source')}"
-                    f"for '{self.options.get('protocol')}' protocol"
-                )
-                raise NotImplementedError
-        elif self.options.get("protocol") == "http":
-            if not self.options.get("source").startswith(("http://", "https://")):
-                logger.error(
-                    f"Source type not implemented yet: {self.options.get('source')} "
-                    f"for '{self.options.get('protocol')}' protocol"
-                )
-                raise NotImplementedError
-            downloader = HttpHandler(
-                source_repository_path_or_uri=self.options.get("source"),
-            )
-        else:
-            logger.critical(
-                f"Protocol '{self.options.get('protocol')}' is not part of supported ones: "
-                f"{self.OPTIONS_SCHEMA.get('protocol').get('possible_values')}"
-            )
-            raise NotImplementedError
-
-        # run download operation
-        downloader.download(destination_local_path=self.qdt_downloaded_repositories)
-
         # check of there are some profiles folders within the downloaded folder
         profiles_folders = self.list_downloaded_profiles()
         if profiles_folders is None:
@@ -369,12 +280,3 @@ class JobProfilesDownloader(GenericJob):
                 copy_function=copy2,
                 dirs_exist_ok=True,
             )
-
-
-# #############################################################################
-# ##### Stand alone program ########
-# ##################################
-
-if __name__ == "__main__":
-    """Standalone execution."""
-    pass

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -24,8 +24,9 @@ from qgis_deployment_toolbelt.jobs.job_plugins_downloader import JobPluginsDownl
 from qgis_deployment_toolbelt.jobs.job_plugins_synchronizer import (
     JobPluginsSynchronizer,
 )
+from qgis_deployment_toolbelt.jobs.job_profiles_downloader import JobProfilesDownloader
 from qgis_deployment_toolbelt.jobs.job_profiles_synchronizer import (
-    JobProfilesDownloader,
+    JobProfilesSynchronizer,
 )
 from qgis_deployment_toolbelt.jobs.job_shortcuts import JobShortcutsManager
 from qgis_deployment_toolbelt.jobs.job_splash_screen import JobSplashScreenManager
@@ -50,6 +51,7 @@ class JobsOrchestrator:
         JobPluginsDownloader,
         JobPluginsSynchronizer,
         JobProfilesDownloader,
+        JobProfilesSynchronizer,
         JobShortcutsManager,
         JobSplashScreenManager,
     )

--- a/scenario.qdt.yml
+++ b/scenario.qdt.yml
@@ -18,20 +18,24 @@ settings:
 # Deployment workflow, step by step
 steps:
   - name: Download profiles from remote git repository
-    uses: qprofiles-manager
+    uses: qprofiles-downloader
     with:
       source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
-      sync_mode: overwrite
       branch: main
 
-  - name: Download plugins
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: overwrite
+
+  - name: Download plugins referenced in installed profiles
     uses: qplugins-downloader
     with:
       force: false
       threads: 5
 
-  - name: Synchronize plugins
+  - name: Synchronize downloaded plugins with those in installed profiles
     uses: qplugins-synchronizer
     with:
       action: create_or_restore

--- a/tests/fixtures/scenarios/good_scenario_profiles_http.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_http.yml
@@ -13,9 +13,13 @@ settings:
   SCENARIO_VALIDATION: true
 
 steps:
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download QGIS profiles from remote location
+    uses: qprofiles-downloader
     with:
       protocol: http
       source: https://raw.githubusercontent.com/Guts/qgis-deployment-cli/examples/
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
       sync_mode: overwrite

--- a/tests/fixtures/scenarios/good_scenario_profiles_only_different.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_only_different.qdt.yml
@@ -14,14 +14,18 @@ settings:
   QGIS_EXE_PATH:
     linux: /usr/bin/qgis
     mac: /usr/bin/qgis
-    windows: "%PROGRAMFILES%/QGIS/3_22/bin/qgis-bin.exe"
+    windows: "%PROGRAMFILES%/QGIS/3_34/bin/qgis-bin.exe"
   SCENARIO_VALIDATION: true
 
 steps:
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
     with:
+      source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
       branch: main
-      source: https://github.com/Guts/qgis-deployment-cli.git
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
       sync_mode: only_different_version

--- a/tests/fixtures/scenarios/good_scenario_profiles_only_missing.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_only_missing.qdt.yml
@@ -18,10 +18,14 @@ settings:
   SCENARIO_VALIDATION: true
 
 steps:
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
     with:
+      source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
       branch: main
-      source: https://github.com/Guts/qgis-deployment-cli.git
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
       sync_mode: only_missing

--- a/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
@@ -26,13 +26,17 @@ steps:
         value: true
         scope: "user"
 
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
     with:
-      action: download
       source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
       branch: main
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: only_new_version
 
   - name: Download plugins
     uses: qplugins-downloader

--- a/tests/fixtures/scenarios/good_scenario_splash_screen_remove.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_splash_screen_remove.qdt.yml
@@ -17,13 +17,17 @@ settings:
   SCENARIO_VALIDATION: true
 
 steps:
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
     with:
-      action: download
       source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
       branch: main
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: only_different_version
 
   - name: Download plugins
     uses: qplugins-downloader

--- a/tests/fixtures/scenarios/good_scenario_with_unexisting_jobs.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_with_unexisting_jobs.qdt.yml
@@ -30,13 +30,17 @@ steps:
         value: true
         scope: "user"
 
-  - name: Synchronize QGIS profiles from remote location
-    uses: qprofiles-manager
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
     with:
-      action: download
       source: https://github.com/Guts/qgis-deployment-cli.git
       protocol: git_remote
       branch: main
+
+  - name: Synchronize downloaded profiles with installed ones
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: overwrite
 
   - name: Download plugins
     uses: qplugins-downloader


### PR DESCRIPTION
This PR is part of #343 and of a whole refactoring.

In this PR:

- deprecating `qprofiles-manager`
- update related documentation and JSON schemas
- remove some outdated source code

## Migration guide

Before:

```yaml
[...]
steps:
  - name: Download profiles from remote git repository and synchronize with installed profiles
    uses: qprofiles-manager
    with:
      source: https://github.com/Guts/qgis-deployment-cli.git
      protocol: git_remote
      sync_mode: overwrite
      branch: main
[...]
```

After:

```yaml
[...]
steps:
  - name: Download profiles from remote git repository
    uses: qprofiles-downloader
    with:
      source: https://github.com/Guts/qgis-deployment-cli.git
      protocol: git_remote
      branch: main

  - name: Synchronize downloaded profiles with installed ones
    uses: qprofiles-synchronizer
    with:
      sync_mode: overwrite
[...]
```