### PR TITLE
packaging: set Python min/max versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 universal = 0
 
 [metadata]
-description-file = README.md
+description_file = README.md
 
 # -- Documentation -----------------------------------
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Topic :: System :: Installation/Setup",
     ],
     # packaging
+    python_requires=">=3.10,<3.12",
     py_modules=["qgis_deployment_toolbelt"],
     packages=find_packages(
         exclude=["contrib", "docs", "*.tests", "*.tests.*", "tests.*", "tests", ".venv"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "Topic :: System :: Installation/Setup",
     ],
     # packaging
-    python_requires=">=3.10,=<3.12",
+    python_requires=">=3.10,<=3.12",
     py_modules=["qgis_deployment_toolbelt"],
     packages=find_packages(
         exclude=["contrib", "docs", "*.tests", "*.tests.*", "tests.*", "tests", ".venv"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "Topic :: System :: Installation/Setup",
     ],
     # packaging
-    python_requires=">=3.10,<3.12",
+    python_requires=">=3.10,=<3.12",
     py_modules=["qgis_deployment_toolbelt"],
     packages=find_packages(
         exclude=["contrib", "docs", "*.tests", "*.tests.*", "tests.*", "tests", ".venv"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "Topic :: System :: Installation/Setup",
     ],
     # packaging
-    python_requires=">=3.10,<=3.12",
+    python_requires=">=3.10,<4",
     py_modules=["qgis_deployment_toolbelt"],
     packages=find_packages(
         exclude=["contrib", "docs", "*.tests", "*.tests.*", "tests.*", "tests", ".venv"]


### PR DESCRIPTION
Until now, it's still possible to install on unsupported Python versions.