### PR TITLE
feat(env variable): add write of environnement variable in .ini files from QDT profile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,10 +114,13 @@ jobs:
       - name: QDT - Echoing version
         run: qdeploy-toolbelt --version
 
-      - name: QDT - Sample scenario
+      - name: QDT - Check upgrade
+        run: qdt upgrade
+
+      - name: QDT - Run sample scenario twice
         run: |
           qgis-deployment-toolbelt --verbose
-          qgis-deployment-toolbelt --verbose
+          qgis-deployment-toolbelt
 
-      - name: QDT - Sample scenario
+      - name: QDT - Run sample scenario a third time
         run: qgis-deployment-toolbelt --verbose --no-logfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,8 @@ jobs:
         run: qdeploy-toolbelt --version
 
       - name: QDT - Check upgrade
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required to avoid GH API rate limit
         run: qdt upgrade
 
       - name: QDT - Run sample scenario twice

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,14 @@ name: "🎳 Tester"
 on:
   push:
     branches:
-        - main
+      - main
     paths:
       - "**/*.py"
       - ".github/workflows/tests.yml"
 
   pull_request:
     branches:
-        - main
+      - main
     paths:
       - "**/*.py"
       - ".github/workflows/tests.yml"
@@ -32,9 +32,9 @@ jobs:
           - ubuntu-22.04
           - windows-latest
         python-version:
-            - "3.10"
-            - "3.11"
-            - "3.12"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -84,9 +84,9 @@ jobs:
           - ubuntu-22.04
           - windows-latest
         python-version:
-            - "3.10"
-            - "3.11"
-            - "3.12"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -115,7 +115,9 @@ jobs:
         run: qdeploy-toolbelt --version
 
       - name: QDT - Sample scenario
-        run: qgis-deployment-toolbelt --verbose
+        run: |
+          qgis-deployment-toolbelt --verbose
+          qgis-deployment-toolbelt --verbose
 
       - name: QDT - Sample scenario
         run: qgis-deployment-toolbelt --verbose --no-logfile

--- a/examples/profiles/Viewer Mode/QGIS/QGIS3.ini
+++ b/examples/profiles/Viewer Mode/QGIS/QGIS3.ini
@@ -1169,3 +1169,5 @@ searchPathsForSVG=/usr/share/qgis/svg/, /home/jmo/Git/Oslandia/QGIS/qgis-deploym
 
 [variables]
 created_with_qdt=true
+current_user=$USER
+updated_variable=profile_variable

--- a/examples/profiles/demo/QGIS/QGIS3.ini
+++ b/examples/profiles/demo/QGIS/QGIS3.ini
@@ -164,3 +164,5 @@ searchPathsForSVG=/usr/share/qgis/svg/
 
 [variables]
 created_with_qdt=true
+current_user=$USER
+updated_variable=profile_variable

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -272,11 +272,16 @@ class JobProfilesSynchronizer(GenericJob):
 
         # copy downloaded profiles into this
         for d in profiles_to_copy:
-            logger.info(f"Copying {d.folder} to {d.path_in_qgis}")
-            d.path_in_qgis.mkdir(parents=True, exist_ok=True)
-            copytree(
-                d.folder,
-                d.path_in_qgis,
-                copy_function=copy2,
-                dirs_exist_ok=True,
-            )
+            if d.path_in_qgis.exists():
+                logger.info(f"Merging {d.folder} to {d.path_in_qgis}")
+                installed_profile = QdtProfile(folder=d.path_in_qgis)
+                d.merge_to(installed_profile)
+            else:
+                logger.info(f"Copying {d.folder} to {d.path_in_qgis}")
+                d.path_in_qgis.mkdir(parents=True, exist_ok=True)
+                copytree(
+                    d.folder,
+                    d.path_in_qgis,
+                    copy_function=copy2,
+                    dirs_exist_ok=True,
+                )

--- a/qgis_deployment_toolbelt/utils/ini_interpolation.py
+++ b/qgis_deployment_toolbelt/utils/ini_interpolation.py
@@ -75,6 +75,33 @@ class EnvironmentVariablesInterpolation(BasicInterpolation):
             )
             return value
 
+    def before_write(
+        self,
+        parser: ConfigParser,
+        section: str,
+        option: str,
+        value: str,
+    ) -> str:
+        """Called before write option=value line in INI file.
+
+        Args:
+            parser (ConfigParser): parser whose function is overloaded
+            section (str): section's name
+            option (str): option's name
+            value (str): value to try to interpolate
+
+        Returns:
+            str: interpolated value
+        """
+        value = super().before_write(parser, section, option, value)
+        try:
+            return expandvars(expanduser(value))
+        except Exception as exc:
+            logger.error(
+                f"Failed to interpolate {value} in {section}/{option}. Trace: {exc}"
+            )
+            return value
+
 
 # #############################################################################
 # ##### Stand alone program ########

--- a/tests/test_utils_ini_interpolation.py
+++ b/tests/test_utils_ini_interpolation.py
@@ -11,10 +11,12 @@
 """
 
 # standard library
+import tempfile
 import unittest
 from configparser import ConfigParser
 from getpass import getuser
 from os import environ, getenv
+from pathlib import Path
 from sys import platform as opersys
 
 # project
@@ -29,6 +31,23 @@ from qgis_deployment_toolbelt.utils.ini_interpolation import (
 
 class TestUtilsIniCustomInterpolation(unittest.TestCase):
     """Test custom INI values' interpolation."""
+
+    def check_config_read_linux(self, config: ConfigParser) -> None:
+        """Check config with environnement variable interpolation for linux
+
+        Args:
+            config (ConfigParser): parser to check
+        """
+        self.assertEqual(config.get(section="test", option="user"), getuser())
+        self.assertEqual(config.get(section="test", option="user_home"), getenv("HOME"))
+        self.assertEqual(
+            config.get(section="test", option="fake_value_from_environment_variable"),
+            getenv("QDT_TEST_ENV_VARIABLE"),
+        )
+        self.assertEqual(
+            config.get(section="test", option="qdt_working_directory"),
+            f"{config.get(section='test', option='user_home')}/.cache/qgis-deployment-toolbelt",
+        )
 
     @unittest.skipIf(opersys == "win32", "Test specific to Linux.")
     def test_ini_env_var_interpolation_linux(self):
@@ -45,8 +64,50 @@ class TestUtilsIniCustomInterpolation(unittest.TestCase):
 
         config = ConfigParser(interpolation=EnvironmentVariablesInterpolation())
         config.read_string(fixtures_configuration)
+        self.check_config_read_linux(config=config)
+
+        environ.pop("QDT_TEST_ENV_VARIABLE")
+
+    @unittest.skipIf(opersys == "win32", "Test specific to Linux.")
+    def test_ini_env_var_interpolation_write_linux(self):
+        """Test interpolation results for ini write."""
+        fixtures_configuration = """
+        [test]
+        user=$USER
+        user_home = $HOME
+        fake_value_from_environment_variable = $QDT_TEST_ENV_VARIABLE
+        qdt_working_directory = %(user_home)s/.cache/qgis-deployment-toolbelt
+
+        """
+        environ["QDT_TEST_ENV_VARIABLE"] = "TEST_VALUE"
+
+        config = ConfigParser(interpolation=EnvironmentVariablesInterpolation())
+        config.read_string(fixtures_configuration)
+
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_write_env_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            # Write new .ini : environnement variable will be written
+            tmp_copy = Path(tmpdirname).joinpath("new_file.ini")
+            with open(tmp_copy, "w") as f:
+                config.write(f)
+            # Check that environnement variable are replaced
+            default_config_parser = ConfigParser()
+            default_config_parser.read(tmp_copy)
+            self.check_config_read_linux(config=default_config_parser)
+
+        environ.pop("QDT_TEST_ENV_VARIABLE")
+
+    def check_config_read_windows(self, config: ConfigParser) -> None:
+        """Check config with environnement variable interpolation for windows
+
+        Args:
+            config (ConfigParser): parser to check
+        """
         self.assertEqual(config.get(section="test", option="user"), getuser())
-        self.assertEqual(config.get(section="test", option="user_home"), getenv("HOME"))
+        self.assertEqual(
+            config.get(section="test", option="user_home"), getenv("USERPROFILE")
+        )
         self.assertEqual(
             config.get(section="test", option="fake_value_from_environment_variable"),
             getenv("QDT_TEST_ENV_VARIABLE"),
@@ -55,8 +116,6 @@ class TestUtilsIniCustomInterpolation(unittest.TestCase):
             config.get(section="test", option="qdt_working_directory"),
             f"{config.get(section='test', option='user_home')}/.cache/qgis-deployment-toolbelt",
         )
-
-        environ.pop("QDT_TEST_ENV_VARIABLE")
 
     @unittest.skipIf(opersys != "win32", "Test specific to Windows.")
     def test_ini_env_var_interpolation_windows(self):
@@ -73,18 +132,36 @@ class TestUtilsIniCustomInterpolation(unittest.TestCase):
 
         config = ConfigParser(interpolation=EnvironmentVariablesInterpolation())
         config.read_string(fixtures_configuration)
-        self.assertEqual(config.get(section="test", option="user"), getuser())
-        self.assertEqual(
-            config.get(section="test", option="user_home"), getenv("USERPROFILE")
-        )
-        self.assertEqual(
-            config.get(section="test", option="fake_value_from_environment_variable"),
-            getenv("QDT_TEST_ENV_VARIABLE"),
-        )
-        self.assertEqual(
-            config.get(section="test", option="qdt_working_directory"),
-            f"{config.get(section='test', option='user_home')}/.cache/qgis-deployment-toolbelt",
-        )
+        self.check_config_read_windows(config=config)
+
+        environ.pop("QDT_TEST_ENV_VARIABLE")
+
+    @unittest.skipIf(opersys != "win32", "Test specific to Windows.")
+    def test_ini_env_var_interpolation_write_windows(self):
+        """Test interpolation results."""
+        fixtures_configuration = """
+        [test]
+        user = $USERNAME
+        user_home = $USERPROFILE
+        fake_value_from_environment_variable = $QDT_TEST_ENV_VARIABLE
+        qdt_working_directory = %(user_home)s/.cache/qgis-deployment-toolbelt
+
+        """
+        environ["QDT_TEST_ENV_VARIABLE"] = "TEST_VALUE"
+
+        config = ConfigParser(interpolation=EnvironmentVariablesInterpolation())
+        config.read_string(fixtures_configuration)
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_write_env_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            # Write new .ini : environnement variable will be written
+            tmp_copy = Path(tmpdirname).joinpath("new_file.ini")
+            with open(tmp_copy, "w") as f:
+                config.write(f)
+            # Check that environnement variable are replaced
+            default_config_parser = ConfigParser()
+            default_config_parser.read(tmp_copy)
+            self.check_config_read_windows(config=default_config_parser)
 
         environ.pop("QDT_TEST_ENV_VARIABLE")
 


### PR DESCRIPTION
- add write of environnement variable in .ini files with implementation of `before_write` in `EnvironmentVariablesInterpolation`
- add merge of `QdtProfile` from installed QGIS folder and downloaded one:
    - copy download folder to temporary folder
    - copy available .ini files from installed QGIS folder
    - merge .ini from download folder and backup updated values

closes #451 