### PR TITLE
feat(installed qgis): add qgis-installation-finder job

### DIFF
--- a/docs/jobs/index.md
+++ b/docs/jobs/index.md
@@ -7,6 +7,7 @@ maxdepth: 1
 glob:
 ---
 environment_variables.md
+qgis_installation_finder.md
 plugins_downloader.md
 plugins_synchronizer.md
 profiles_downloader.md

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -2,6 +2,8 @@
 
 Use this job to find installed QGIS version for automatic definition of QDT environnement variable `QDT_QGIS_EXE_PATH` (used for shortcut creation).
 
+If the environment variable is already defined and a valid QGIS installation is found by this variable, the job is skipped.
+
 ----
 
 ## Compatibility

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -58,8 +58,6 @@ On Windows QDT try to locate installed versions in the current directories :
 
 By default, the latest version is used.
 
-Since we can't define which version is installed by OSGeo4W this will be the last version used if available
-
 ----
 
 ## Schema

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -1,6 +1,6 @@
 # QGIS installation finder
 
-Use this job to find installed QGIS version for automatic definition of QDT environnement variable `QDT_QGIS_EXE_PATH` needed for shortcut creation
+Use this job to find installed QGIS version for automatic definition of QDT environnement variable `QDT_QGIS_EXE_PATH` (used for shortcut creation).
 
 ----
 
@@ -32,11 +32,9 @@ Sample job configuration in your scenario file:
 
 ### version_priority
 
-Multiple versions of QGIS can be installed on Windows.
+Since multiple versions of QGIS can be easily installed on Windows, this option is used to specify the preferred QGIS version.
 
-This option is used to specify the preferred QGIS version
-
-For example if you define :
+For example if you define:
 
 ```yaml
 - name: Find installed QGIS
@@ -51,7 +49,7 @@ QDT will first use 3.34.z versions. If none are available it will use 3.36.z ver
 
 If multiple 3.34.z versions are available, the latest will be used. For example if 3.34.1 and 3.34.5 version are available, 3.34.5 will be used.
 
-If no version from version_priority` is available, it will use the latest found version.
+If any version of `version_priority` is available, then the most recent version found is used.
 
 ### if_not_found
 
@@ -60,20 +58,19 @@ This option determines the action to be taken if QGIS is not found during the se
 Possible_values:
 
 - `warning` (_default_): if no version found, a warning is displayed in QDT logs
-- `error`: if no version found, QDT stop and the other jobs are not run
+- `error`: if no version found, QDT stops and the other jobs are not run
 
 ----
 
 ## How does it work
 
-On Linux, QDT locate installed QGIS with `which`command.
-
-On Windows QDT try to locate installed versions in the current directories :
+On Linux, QDT locates installed QGIS with `which` command.  
+On Windows QDT tries to locate installed versions in the following directories:
 
 - `%PROGRAMFILES%\\QGIS x.y.z\\bin\`
 - `%QDT_OSGEO4W_INSTALL_DIR%` (default value : `C:\\OSGeo4W`)
 
-By default, the latest version found is used.
+By default, the most recent version found is used.
 
 ----
 

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -1,6 +1,6 @@
 # QGIS installation finder
 
-Use this job to find installed QGIS version to auto definition QDT environnement variable `QDT_QGIS_EXE_PATH` needed for shortcut creation
+Use this job to find installed QGIS version for automatic definition of QDT environnement variable `QDT_QGIS_EXE_PATH` needed for shortcut creation
 
 ----
 
@@ -32,9 +32,9 @@ Sample job configuration in your scenario file:
 
 ### version_priority
 
-Multiple QGIS version can be installed in Windows, this option prioritize the version to use.
+Multiple versions of QGIS can be installed on Windows.
 
-It define a list of version to use by priority.
+This option is used to specify the preferred QGIS version
 
 For example if you define :
 
@@ -55,7 +55,7 @@ If no version from version_priority` is available, it will use the latest found 
 
 ### if_not_found
 
-Job behavior if QGIS is not found.
+This option determines the action to be taken if QGIS is not found during the search process.
 
 Possible_values:
 

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -42,8 +42,8 @@ Job behavior if QGIS is not found.
 
 Possible_values:
 
-- `warning`: if no version found, a warning is displayed in QDT logs
-- `error` (_default_): if no version found, QDT stop and the other jobs are not run
+- `warning` (_default_): if no version found, a warning is displayed in QDT logs
+- `error`: if no version found, QDT stop and the other jobs are not run
 
 ----
 

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -1,0 +1,62 @@
+# QGIS installation finder
+
+Use this job to find installed QGIS version to auto definition QDT environnement variable `QDT_QGIS_EXE_PATH` needed for shortcut creation
+
+----
+
+## Use it
+
+Sample job configuration in your scenario file:
+
+```yaml
+- name: Find installed QGIS
+  uses: qgis-installation-finder
+  with:
+    version_priority:
+      - "3.36"
+    if_not_found: error
+```
+
+----
+
+## Options
+
+### version_priority
+
+Multiple QGIS version can be installed in Windows, this option prioritize the version to use.
+
+It define a list of version to use by priority.
+
+### if_not_found
+
+Job behavior if QGIS is not found.
+
+Possible_values:
+
+- `warning`: if no version found, a warning is displayed in QDT logs
+- `error` (_default_): if no version found, QDT stop and the other jobs are not run
+
+----
+
+## How does it work
+
+On Linux, QDT locate installed QGIS with `which`command.
+
+On Windows QDT try to locate installed versions in the current directories :
+
+- `%PROGRAMFILES%\\QGIS x.y.z\\bin\`
+- `C:\\OSGeo4W`
+- `C:\\OSGeo4W64`
+
+By default, the latest version is used.
+
+Since we can't define which version is installed by OSGeo4W this will be the last version used if available
+
+----
+
+## Schema
+
+```{eval-rst}
+.. literalinclude:: ../schemas/scenario/jobs/qgis-installation-finder.json
+  :language: json
+```

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -36,6 +36,23 @@ Multiple QGIS version can be installed in Windows, this option prioritize the ve
 
 It define a list of version to use by priority.
 
+For example if you define :
+
+```yaml
+- name: Find installed QGIS
+  uses: qgis-installation-finder
+  with:
+    version_priority:
+      - "3.34"
+      - "3.36"
+```
+
+QDT will first use 3.34.z versions. If none are available it will use 3.36.z versions.
+
+If multiple 3.34.z versions are available, the latest will be used. For example if 3.34.1 and 3.34.5 version are available, 3.34.5 will be used.
+
+If no version from version_priority` is available, it will use the latest found version.
+
 ### if_not_found
 
 Job behavior if QGIS is not found.
@@ -56,7 +73,7 @@ On Windows QDT try to locate installed versions in the current directories :
 - `%PROGRAMFILES%\\QGIS x.y.z\\bin\`
 - `%QDT_OSGEO4W_INSTALL_DIR%` (default value : `C:\\OSGeo4W`)
 
-By default, the latest version is used.
+By default, the latest version found is used.
 
 ----
 

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -4,6 +4,15 @@ Use this job to find installed QGIS version to auto definition QDT environnement
 
 ----
 
+## Compatibility
+
+This job is compatible with:
+
+- Windows
+- Linux
+
+----
+
 ## Use it
 
 Sample job configuration in your scenario file:
@@ -45,8 +54,7 @@ On Linux, QDT locate installed QGIS with `which`command.
 On Windows QDT try to locate installed versions in the current directories :
 
 - `%PROGRAMFILES%\\QGIS x.y.z\\bin\`
-- `C:\\OSGeo4W`
-- `C:\\OSGeo4W64`
+- `%QDT_OSGEO4W_INSTALL_DIR%` (default value : `C:\\OSGeo4W`)
 
 By default, the latest version is used.
 

--- a/docs/jobs/qgis_installation_finder.md
+++ b/docs/jobs/qgis_installation_finder.md
@@ -51,6 +51,8 @@ If multiple 3.34.z versions are available, the latest will be used. For example 
 
 If any version of `version_priority` is available, then the most recent version found is used.
 
+The environment variable `QDT_PREFERRED_QGIS_VERSION` is used as top priority if defined.
+
 ### if_not_found
 
 This option determines the action to be taken if QGIS is not found during the search process.

--- a/docs/schemas/scenario/jobs/generic.json
+++ b/docs/schemas/scenario/jobs/generic.json
@@ -30,7 +30,8 @@
           "qprofiles-synchronizer",
           "qprofiles-manager",
           "shortcuts-manager",
-          "splash-screen-manager"
+          "splash-screen-manager",
+          "qgis-installation-finder"
         ],
         "deprecated": [
           "qprofiles-manager"
@@ -114,7 +115,17 @@
             "$ref": "splash-screen-manager.json"
           }
         }
-      }
+      },
+      {
+        "properties": {
+          "uses": {
+            "const": "qgis-installation-finder"
+          },
+          "with": {
+            "$ref": "qgis-installation-finder.json"
+          }
+        }
+      },
     ],
     "required": [
       "name",

--- a/docs/schemas/scenario/jobs/generic.json
+++ b/docs/schemas/scenario/jobs/generic.json
@@ -24,14 +24,14 @@
         "maxLength": 255,
         "enum": [
           "manage-env-vars",
+          "qgis-installation-finder",
           "qplugins-downloader",
           "qplugins-synchronizer",
           "qprofiles-downloader",
           "qprofiles-synchronizer",
           "qprofiles-manager",
           "shortcuts-manager",
-          "splash-screen-manager",
-          "qgis-installation-finder"
+          "splash-screen-manager"
         ],
         "deprecated": [
           "qprofiles-manager"

--- a/docs/schemas/scenario/jobs/qgis-installation-finder.json
+++ b/docs/schemas/scenario/jobs/qgis-installation-finder.json
@@ -13,7 +13,7 @@
         "type": "array"
       },
       "if_not_found": {
-        "default": "error",
+        "default": "warning",
         "description": "Behavior if no QGIS installation found.",
         "enum": [
           "warning",

--- a/docs/schemas/scenario/jobs/qgis-installation-finder.json
+++ b/docs/schemas/scenario/jobs/qgis-installation-finder.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Guts/qgis-deployment-cli/raw/main/docs/schemas/scenario/jobs/qgis-installation-finder.json",
+  "description": "Job in charge of findind installed QGIS version on computer.",
+  "title": "QGIS installation finder",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "version_priority": {
+        "default": "",
+        "description": "Define QGIS version priority for search.",
+        "type": "array"
+      },
+      "if_not_found": {
+        "default": "error",
+        "description": "Behavior if no QGIS installation found.",
+        "enum": [
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/schemas/scenario/jobs/qgis-installation-finder.json
+++ b/docs/schemas/scenario/jobs/qgis-installation-finder.json
@@ -10,7 +10,10 @@
       "version_priority": {
         "default": "",
         "description": "Define QGIS version priority for search.",
-        "type": "array"
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
       "if_not_found": {
         "default": "warning",

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -25,6 +25,7 @@ Some others parameters can be set using environment variables.
 | `QDT_LOGS_DIR` | Folder where QDT writes the log files, which are automatically rotated. | `~/.cache/qgis-deployment-toolbelt/logs/` |
 | `QDT_QGIS_EXE_PATH` | Path to the QGIS executable to use. Used in shortcuts. | `/usr/bin/qgis` on Linux and MacOS, `%PROGRAMFILES%/QGIS 3.28/bin/qgis-ltr-bin.exe` on Windows. |
 | `QDT_SSL_USE_SYSTEM_STORES` | By default, a bundle of SSL certificates is used, through [certifi](https://pypi.org/project/certifi/). If this environment variable is set to True, QDT tries to uses the system certificates store. Based on [truststore](https://truststore.readthedocs.io/). See also [How to use custom SSL certificates](../guides/howto_use_custom_ssl_certs.md).  | `False` |
+| `QDT_OSGEO4W_INSTALL_DIR` | Path to the OSGEO4W install directory. Used to search for installed QGIS and shortcuts creation. | `C:\\OSGeo4W`. |
 
 ----
 

--- a/examples/scenarios/demo-scenario-http.qdt.yml
+++ b/examples/scenarios/demo-scenario-http.qdt.yml
@@ -12,6 +12,11 @@ settings:
 
 # Deployment workflow, step by step
 steps:
+  - name: Find installed QGIS
+    uses: qgis-installation-finder
+    with:
+      version_priority:
+        - "3.36"
   - name: Download profiles from remote git repository
     uses: qprofiles-downloader
     with:

--- a/examples/scenarios/demo-scenario.qdt.yml
+++ b/examples/scenarios/demo-scenario.qdt.yml
@@ -17,6 +17,11 @@ settings:
 
 # Deployment workflow, step by step
 steps:
+  - name: Find installed QGIS
+    uses: qgis-installation-finder
+    with:
+      version_priority:
+        - "3.36"
   - name: Download profiles from remote git repository
     uses: qprofiles-downloader
     with:

--- a/qgis_deployment_toolbelt/exceptions.py
+++ b/qgis_deployment_toolbelt/exceptions.py
@@ -105,3 +105,12 @@ class SplashScreenBadDimensions(Exception):
             " dimensions recomended by QGIS for splash screen: 600x300."
         )
         super().__init__(self.message)
+
+
+class QgisInstallNotFound(Exception):
+    """When no QGIS installation are found."""
+
+    def __init__(self):
+        """Initialization method."""
+        self.message = "No QGIS installation found."
+        super().__init__(self.message)

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 # ##################################
 
 OSGEO4W_VERSION = "OSGeo4W"
-OSGEO4W_64_VERSION = "OSGeo4W64"
 
 
 class JobQgisInstallationFinder(GenericJob):
@@ -143,9 +142,6 @@ class JobQgisInstallationFinder(GenericJob):
             if OSGEO4W_VERSION in used_version:
                 used_version.remove(OSGEO4W_VERSION)
                 used_version.append(OSGEO4W_VERSION)
-            if OSGEO4W_64_VERSION in used_version:
-                used_version.remove(OSGEO4W_64_VERSION)
-                used_version.append(OSGEO4W_64_VERSION)
             return used_version[0]
         return None
 
@@ -219,18 +215,11 @@ class JobQgisInstallationFinder(GenericJob):
                     found_version[version] = qgis_exe
 
         # OSGEO4W
-        install_dir = "C:\\OSGeo4W"
+        install_dir = os.environ.get("QDT_OSGEO4W_INSTALL_DIR", "C:\\OSGeo4W")
         if qgis_exe := JobQgisInstallationFinder._get_qgis_bin_in_install_dir(
             install_dir
         ):
             found_version[OSGEO4W_VERSION] = qgis_exe
-
-        # OSGEO4W64
-        install_dir = "C:\\OSGeo4W64"
-        if qgis_exe := JobQgisInstallationFinder._get_qgis_bin_in_install_dir(
-            install_dir
-        ):
-            found_version[OSGEO4W_64_VERSION] = qgis_exe
 
         return found_version
 

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -119,7 +119,7 @@ class JobQgisInstallationFinder(GenericJob):
                     return latest_matching_version
             version_priority_str = ",".join(self.options["version_priority"])
             logger.info(
-                f"QGIS version(s) [{version_priority_str}] not found. Using latest found version {latest_version} : {latest_qgis}"
+                f"QGIS version(s) [{version_priority_str}] not found. Using most recent found version {latest_version} : {latest_qgis}"
             )
 
         return latest_qgis

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -1,0 +1,242 @@
+#! python3  # noqa: E265
+
+"""
+    Tools to find installed QGIS version
+
+    Author: Jean-Marie KERLOCH (https://github.com/jmkerloch)
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+
+# Standard library
+import logging
+import os
+import re
+from os.path import expandvars
+from shutil import which
+from sys import platform as opersys
+
+# package
+from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+
+# logs
+logger = logging.getLogger(__name__)
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+OSGEO4W_VERSION = "OSGeo4W"
+OSGEO4W_64_VERSION = "OSGeo4W64"
+
+
+class JobQgisInstallationFinder(GenericJob):
+    """
+    Class to find installed QGIS version
+    """
+
+    ID: str = "qgis-installation-finder"
+    OPTIONS_SCHEMA: dict = {
+        "version_priority": {
+            "type": (list, str),
+            "required": False,
+            "default": None,
+            "possible_values": None,
+            "condition": None,
+        },
+        "if_not_found": {
+            "type": str,
+            "required": False,
+            "default": "error",
+            "possible_values": ("warning", "error"),
+            "condition": "in",
+        },
+    }
+
+    def __init__(self, options: dict) -> None:
+        """Instantiate the class.
+        Args:
+            options (dict): job options
+        """
+
+        super().__init__()
+        self.options: dict = self.validate_options(options)
+
+    def run(self) -> None:
+        """Define QDT_QGIS_EXE_PATH for shortcut creation"""
+
+        if opersys not in ("linux", "win32"):
+            logger.error(f"This job does not support your operating system: {opersys}")
+            return
+
+        installed_qgis_path: str | None = self.get_installed_qgis_path()
+
+        if installed_qgis_path:
+            os.environ["QDT_QGIS_EXE_PATH"] = installed_qgis_path
+
+        # log
+        logger.debug(f"Job {self.ID} ran successfully.")
+
+    # -- INTERNAL LOGIC ------------------------------------------------------
+    def get_installed_qgis_path(self) -> str | None:
+        """Get list of installed qgis
+
+        Returns:
+            str | None : installed qgis path
+        """
+        if opersys == "linux":
+            return self._get_linux_installed_qgis_path()
+        elif opersys == "win32":
+            # Check for installed version in the default install directory
+            found_versions = self._get_windows_installed_qgis_path()
+            if len(found_versions) == 0:
+                return None
+
+            logger.debug(f"Found installed QGIS : {found_versions}")
+            latest_version = self._get_latest_version_from_list(
+                versions=list(found_versions.keys())
+            )
+            latest_qgis = found_versions[latest_version]
+
+            if "version_priority" in self.options:
+                for version in self.options["version_priority"]:
+                    if latest_matching_version := self._get_latest_matching_version_path(
+                        found_versions=found_versions, version=version
+                    ):
+                        return latest_matching_version
+                version_priority_str = ",".join(self.options["version_priority"])
+                logger.info(
+                    f"QGIS version(s) [{version_priority_str}] not found. Using latest found version {latest_qgis}"
+                )
+
+            return latest_qgis
+        return None
+
+    @staticmethod
+    def _get_latest_version_from_list(versions: list[str]) -> str | None:
+        """Get latest version from a list, OSGEO4W are last
+
+        Args:
+            versions (list[str]): list of found version
+
+        Returns:
+            str | None: latest version, None if no version provided
+        """
+        if len(versions):
+            used_version = versions
+            used_version.sort(reverse=True)
+            # OSGEO4W version must be check last because we can't define version
+            if OSGEO4W_VERSION in used_version:
+                used_version.remove(OSGEO4W_VERSION)
+                used_version.append(OSGEO4W_VERSION)
+            if OSGEO4W_64_VERSION in used_version:
+                used_version.remove(OSGEO4W_64_VERSION)
+                used_version.append(OSGEO4W_64_VERSION)
+            return used_version[0]
+        return None
+
+    @staticmethod
+    def _get_latest_matching_version_path(
+        found_versions: dict[str, str], version: str
+    ) -> str | None:
+        """Get latest version path matching a wanted version
+
+        Args:
+            found_versions (dict[str, str]): dict of found versions
+            version (str): wanted version
+
+        Returns:
+            str | None: latest matching version path, None if not found
+        """
+        match_versions = []
+        for found_version in found_versions.keys():
+            if found_version.startswith(version):
+                match_versions.append(found_version)
+        # Use latest version
+        if latest_version := JobQgisInstallationFinder._get_latest_version_from_list(
+            match_versions
+        ):
+            return found_versions[latest_version]
+        return None
+
+    @staticmethod
+    def _get_qgis_bin_in_install_dir(install_dir: str) -> str | None:
+        """Get QGIS binary path from an install directory
+
+        Args:
+            install_dir (str): install directory
+
+        Returns:
+            str | None: QGIS bin path, None if not found
+        """
+        binary_pattern = re.compile(r"qgis(-ltr)?-bin\.exe", re.IGNORECASE)
+        # Check if the bin directory exists within this directory
+        bin_dir = os.path.join(install_dir, "bin")
+        if os.path.exists(bin_dir):
+            # Check if any binary file matches the pattern in the bin directory
+            for filename in os.listdir(bin_dir):
+                if binary_pattern.match(filename):
+                    qgis_exe = os.path.join(bin_dir, filename)
+                    return qgis_exe
+        return None
+
+    @staticmethod
+    def _get_windows_installed_qgis_path() -> dict[str, str]:
+        """Get dict of installed QGIS version in common install directory
+
+        Returns:
+            dict[str, str]: dict of QGIS version and QGIS bin path
+        """
+        # Check for installed version in the default install directory
+        found_version = {}
+
+        # Program files
+        prog_file_dir = expandvars("%PROGRAMFILES%")
+        directory_pattern = re.compile(r"QGIS (\d+)\.(\d+)\.(\d+)", re.IGNORECASE)
+        for dir_name in os.listdir(prog_file_dir):
+            # Check if the directory name matches the pattern
+            match = directory_pattern.match(dir_name)
+            if match:
+                version = match.group(1) + "." + match.group(2) + "." + match.group(3)
+                install_dir = os.path.join(prog_file_dir, dir_name)
+                if qgis_exe := JobQgisInstallationFinder._get_qgis_bin_in_install_dir(
+                    install_dir
+                ):
+                    found_version[version] = qgis_exe
+
+        # OSGEO4W
+        install_dir = "C:\\OSGeo4W"
+        if qgis_exe := JobQgisInstallationFinder._get_qgis_bin_in_install_dir(
+            install_dir
+        ):
+            found_version[OSGEO4W_VERSION] = qgis_exe
+
+        # OSGEO4W64
+        install_dir = "C:\\OSGeo4W64"
+        if qgis_exe := JobQgisInstallationFinder._get_qgis_bin_in_install_dir(
+            install_dir
+        ):
+            found_version[OSGEO4W_64_VERSION] = qgis_exe
+
+        return found_version
+
+    @staticmethod
+    def _get_linux_installed_qgis_path() -> str | None:
+        """Get install qgis path for linux operating system with which
+
+        Returns:
+            str | None: qgis install path, None if not found
+        """
+        # use which to find installed qgis
+        if which_qgis_path := which("qgis"):
+            logger.debug(f"QGIS path found using which: {which_qgis_path}")
+            return which_qgis_path
+        return None

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -20,6 +20,7 @@ from shutil import which
 from sys import platform as opersys
 
 # package
+from qgis_deployment_toolbelt.exceptions import QgisInstallNotFound
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 
 # #############################################################################
@@ -81,6 +82,11 @@ class JobQgisInstallationFinder(GenericJob):
 
         if installed_qgis_path:
             os.environ["QDT_QGIS_EXE_PATH"] = installed_qgis_path
+        else:
+            if self.options.get("if_not_found", "error") == "error":
+                raise QgisInstallNotFound()
+            else:
+                logger.warning("No QGIS installation found")
 
         # log
         logger.debug(f"Job {self.ID} ran successfully.")

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -55,7 +55,7 @@ class JobQgisInstallationFinder(GenericJob):
         "if_not_found": {
             "type": str,
             "required": False,
-            "default": "error",
+            "default": "warning",
             "possible_values": ("warning", "error"),
             "condition": "in",
         },
@@ -82,7 +82,7 @@ class JobQgisInstallationFinder(GenericJob):
         if installed_qgis_path:
             os.environ["QDT_QGIS_EXE_PATH"] = installed_qgis_path
         else:
-            if self.options.get("if_not_found", "error") == "error":
+            if self.options.get("if_not_found", "warning") == "error":
                 raise QgisInstallNotFound()
             else:
                 logger.warning("No QGIS installation found")

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -111,12 +111,20 @@ class JobQgisInstallationFinder(GenericJob):
         )
         latest_qgis = found_versions[latest_version]
 
+        version_priority: list[str] = []
         if "version_priority" in self.options:
-            for version in self.options["version_priority"]:
-                if latest_matching_version := self._get_latest_matching_version_path(
-                    found_versions=found_versions, version=version
-                ):
-                    return latest_matching_version
+            version_priority = self.options["version_priority"]
+
+        # Add preferred qgis version on top of the list
+        if "QDT_PREFERRED_QGIS_VERSION" in os.environ:
+            version_priority.insert(0, os.environ["QDT_PREFERRED_QGIS_VERSION"])
+
+        for version in version_priority:
+            if latest_matching_version := self._get_latest_matching_version_path(
+                found_versions=found_versions, version=version
+            ):
+                return latest_matching_version
+
             version_priority_str = ",".join(self.options["version_priority"])
             logger.info(
                 f"QGIS version(s) [{version_priority_str}] not found. Using most recent found version {latest_version} : {latest_qgis}"

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -28,6 +28,9 @@ from qgis_deployment_toolbelt.jobs.job_profiles_downloader import JobProfilesDow
 from qgis_deployment_toolbelt.jobs.job_profiles_synchronizer import (
     JobProfilesSynchronizer,
 )
+from qgis_deployment_toolbelt.jobs.job_qgis_installation_finder import (
+    JobQgisInstallationFinder,
+)
 from qgis_deployment_toolbelt.jobs.job_shortcuts import JobShortcutsManager
 from qgis_deployment_toolbelt.jobs.job_splash_screen import JobSplashScreenManager
 
@@ -54,6 +57,7 @@ class JobsOrchestrator:
         JobProfilesSynchronizer,
         JobShortcutsManager,
         JobSplashScreenManager,
+        JobQgisInstallationFinder,
     )
     PACKAGE_NAME: str = "qgis_deployment_toolbelt.jobs"
 

--- a/tests/test_job_qgis_installation_finder.py
+++ b/tests/test_job_qgis_installation_finder.py
@@ -52,21 +52,11 @@ class TestJobQgisInstallationFinder(unittest.TestCase):
     # -- TESTS ---------------------------------------------------------
     def test_get_latest_version_from_list(self):
         """Test definition of latest version from a list of version"""
-
-        # OSGeo4W is last
         self.assertEqual(
             JobQgisInstallationFinder._get_latest_version_from_list(
-                ["3.25.1", "4.0.1", "3.28.2", "OSGeo4W"]
+                ["3.25.1", "4.0.1", "3.28.2"]
             ),
             "4.0.1",
-        )
-
-        # OSGeo4W consider last before OSGeo4W64
-        self.assertEqual(
-            JobQgisInstallationFinder._get_latest_version_from_list(
-                ["OSGeo4W", "OSGeo4W64"]
-            ),
-            "OSGeo4W",
         )
 
     def test_get_latest_matching_version_path(self):
@@ -79,7 +69,6 @@ class TestJobQgisInstallationFinder(unittest.TestCase):
                     "3.25.1": "/path/to/3_25_1",
                     "3.25.8": "/path/to/3_25_8",
                     "3.25.2": "/path/to/3_25_2",
-                    "OSGeo4W64": "/path/to/OSGeo4W64",
                 },
                 "3.25",
             ),
@@ -93,7 +82,6 @@ class TestJobQgisInstallationFinder(unittest.TestCase):
                     "3.25.1": "/path/to/3_25_1",
                     "3.25.8": "/path/to/3_25_8",
                     "3.25.2": "/path/to/3_25_2",
-                    "OSGeo4W64": "/path/to/OSGeo4W64",
                 },
                 "3.36",
             )

--- a/tests/test_job_qgis_installation_finder.py
+++ b/tests/test_job_qgis_installation_finder.py
@@ -1,0 +1,100 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+    .. code-block:: python
+
+        # for whole test
+        python -m unittest tests.job_qgis_installation_finder
+        # for specific
+        python -m unittest tests.job_qgis_installation_finder
+            .TestJobQgisInstallationFinder.test_get_latest_version_from_list
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+
+# Standard library
+import unittest
+
+# package
+from qgis_deployment_toolbelt.jobs.job_qgis_installation_finder import (
+    JobQgisInstallationFinder,
+)
+
+# 3rd party
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class TestJobQgisInstallationFinder(unittest.TestCase):
+    """Test module."""
+
+    # -- Standard methods --------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """Executed when module is loaded before any test."""
+
+    # standard methods
+    def setUp(self):
+        """Fixtures prepared before each test."""
+        pass
+
+    def tearDown(self):
+        """Executed after each test."""
+        pass
+
+    # -- TESTS ---------------------------------------------------------
+    def test_get_latest_version_from_list(self):
+        """Test definition of latest version from a list of version"""
+
+        # OSGeo4W is last
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_version_from_list(
+                ["3.25.1", "4.0.1", "3.28.2", "OSGeo4W"]
+            ),
+            "4.0.1",
+        )
+
+        # OSGeo4W consider last before OSGeo4W64
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_version_from_list(
+                ["OSGeo4W", "OSGeo4W64"]
+            ),
+            "OSGeo4W",
+        )
+
+    def test_get_latest_matching_version_path(self):
+        """Test definition of latest version from a list of version"""
+
+        # Matching version
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_matching_version_path(
+                {
+                    "3.25.1": "/path/to/3_25_1",
+                    "3.25.8": "/path/to/3_25_8",
+                    "3.25.2": "/path/to/3_25_2",
+                    "OSGeo4W64": "/path/to/OSGeo4W64",
+                },
+                "3.25",
+            ),
+            "/path/to/3_25_8",
+        )
+
+        # No matching version
+        self.assertIsNone(
+            JobQgisInstallationFinder._get_latest_matching_version_path(
+                {
+                    "3.25.1": "/path/to/3_25_1",
+                    "3.25.8": "/path/to/3_25_8",
+                    "3.25.2": "/path/to/3_25_2",
+                    "OSGeo4W64": "/path/to/OSGeo4W64",
+                },
+                "3.36",
+            )
+        )


### PR DESCRIPTION
related #273

- add job `qgis-installation-finder`
- search for QGIS installation in default installation folder:
    - with `which` on Linux
    - `%PROGRAMFILES%` on Windows
    - new env var `QDT_OSGEO4W_INSTALL_DIR` for OSGeo4W (default `C:\\OSGeo4W`)
- define QGIS binary version with `--version` and string parsing
- add option for version in priority