### PR TITLE
fix(logs): unreachable profile-attributes in logs

### DIFF
--- a/qgis_deployment_toolbelt/jobs/job_splash_screen.py
+++ b/qgis_deployment_toolbelt/jobs/job_splash_screen.py
@@ -138,10 +138,16 @@ class JobSplashScreenManager(GenericJob):
 
                 # now, splash screen image should be at {profile_dir}/images/splash.png
                 if not installed_splash_screen_filepath.is_file():
-                    logger.debug(
-                        "No splash screen found or defined for profile: "
-                        f"{profile_installed.name} ({profile_installed.path_in_qgis})"
-                    )
+                    if isinstance(profile_installed, QdtProfile):
+                        logger.debug(
+                            "No splash screen found or defined for profile: "
+                            f"{profile_installed.name} ({profile_installed.path_in_qgis})"
+                        )
+                    else:
+                        logger.debug(
+                            "No splash screen found or defined for profile: "
+                            f"{profile_downloaded.folder} ({profile_downloaded.path_in_qgis})"
+                        )
                     continue
 
                 # check image size to fit QGIS restrictions


### PR DESCRIPTION
Following #481, this PR fixes the case where a profile is not installed because of not matching defined rules but QDT is failing because of Splash Screen job tries to log a `profile.name` that does not exist in that case:


```python
2024-04-18 15:40:56||ERROR||check_path||check_path_exists||145||C:\Users\runneradmin\AppData\Roaming\QGIS\QGIS3\profiles\QDT Only Linux\QGIS\QGIS3.ini doesn't exist. Attempt 2/2. Game over.
2024-04-18 15:40:56||INFO||qgis_ini_handler||__init__||117||The specified file does not exist: C:\Users\runneradmin\AppData\Roaming\QGIS\QGIS3\profiles\QDT Only Linux\QGIS\QGIS3.ini.
2024-04-18 15:40:56||INFO||job_splash_screen||run||135||No profile.json found for profile 'C:\Users\runneradmin\.cache\qgis-deployment-toolbelt\repositories\qdt-demo-scenario\examples\profiles\only_linux'
2024-04-18 15:40:56||ERROR||bouncer||exit_cli_error||43||'NoneType' object has no attribute 'name'
Traceback (most recent call last):
  File "d:\a\qgis-deployment-cli\qgis-deployment-cli\qgis_deployment_toolbelt\commands\deployment.py", line 205, in run
    job.run()
  File "d:\a\qgis-deployment-cli\qgis-deployment-cli\qgis_deployment_toolbelt\jobs\job_splash_screen.py", line 143, in run
    f"{profile_installed.name} ({profile_installed.path_in_qgis})"
AttributeError: 'NoneType' object has no attribute 'name'
2024-04-18 15:40:56||ERROR||bouncer||exit_cli_error||44||Please, read the full detailed log: C:\Users\runneradmin\.cache\qgis-deployment-toolbelt\logs\QGISDeploymentToolbelt_0.33.0.log
'NoneType' object has no attribute 'name'
2024-04-18 15:40:57||WARNING||shortcuts||__init__||110||Executable does not exist: C:\Program Files\QGIS 3.34.4\bin\qgis-ltr-bin.exe. Shortcuts might not work. Check and fix your scenario.
2024-04-18 15:40:57||WARNING||shortcuts||__init__||110||Executable does not exist: C:\Program Files\QGIS 3.34.4\bin\qgis-ltr-bin.exe. Shortcuts might not work. Check and fix your scenario.
2024-04-18 15:40:57||WARNING||job_splash_screen||run||162||Profile qdt_demo -C:\Users\runneradmin\AppData\Roaming\QGIS\QGIS3\profiles\qdt_demo\images\splash.png dimensions (1000, 479) do not comply with  dimensions recomended by QGIS for splash screen: 600x300.
2024-04-18 15:40:57||ERROR||check_path||check_path_exists||145||C:\Users\runneradmin\AppData\Roaming\QGIS\QGIS3\profiles\QDT Only Linux\QGIS\QGIS3.ini doesn't exist. Attempt 2/2. Game over.
2024-04-18 15:40:57||ERROR||bouncer||exit_cli_error||43||'NoneType' object has no attribute 'name'
Traceback (most recent call last):
  File "d:\a\qgis-deployment-cli\qgis-deployment-cli\qgis_deployment_toolbelt\commands\deployment.py", line 205, in run
    job.run()
  File "d:\a\qgis-deployment-cli\qgis-deployment-cli\qgis_deployment_toolbelt\jobs\job_splash_screen.py", line 143, in run
    f"{profile_installed.name} ({profile_installed.path_in_qgis})"
AttributeError: 'NoneType' object has no attribute 'name'
2024-04-18 15:40:57||ERROR||bouncer||exit_cli_error||44||Please, read the full detailed log: C:\Users\runneradmin\.cache\qgis-deployment-toolbelt\logs\QGISDeploymentToolbelt_0.33.0.log
'NoneType' object has no attribute 'name'
```