### PR TITLE
feature(rules): retrieve user extended data using win32 API

### DIFF
--- a/qgis_deployment_toolbelt/profiles/rules_context.py
+++ b/qgis_deployment_toolbelt/profiles/rules_context.py
@@ -24,6 +24,10 @@ from qgis_deployment_toolbelt.utils.user_groups import (
     get_user_domain_groups,
     get_user_local_groups,
 )
+from qgis_deployment_toolbelt.utils.win32utils import (
+    ExtendedNameFormat,
+    get_current_user_extended_data,
+)
 
 # #############################################################################
 # ########## Globals ###############
@@ -100,6 +104,16 @@ class QdtRulesContext:
             "groups_local": get_user_local_groups(),
             "groups_domain": get_user_domain_groups(),
         }
+
+    @property
+    def _context_user_directory(self) -> dict:
+        """Returns a dictionary containing user informations that can be used in QDT Rules
+            context.
+
+        Returns:
+            dict: dict user information.
+        """
+        return {k.name: get_current_user_extended_data(k) for k in ExtendedNameFormat}
 
     # -- EXPORT
     def to_dict(self) -> dict:

--- a/qgis_deployment_toolbelt/profiles/rules_context.py
+++ b/qgis_deployment_toolbelt/profiles/rules_context.py
@@ -99,21 +99,19 @@ class QdtRulesContext:
         Returns:
             dict: dict user information.
         """
+        if opersys == "win32":
+            windows_extended = {
+                k.name: get_current_user_extended_data(k) for k in ExtendedNameFormat
+            }
+        else:
+            windows_extended = None
+
         return {
             "name": getuser(),
             "groups_local": get_user_local_groups(),
             "groups_domain": get_user_domain_groups(),
+            "windows_extended": windows_extended,
         }
-
-    @property
-    def _context_user_directory(self) -> dict:
-        """Returns a dictionary containing user informations that can be used in QDT Rules
-            context.
-
-        Returns:
-            dict: dict user information.
-        """
-        return {k.name: get_current_user_extended_data(k) for k in ExtendedNameFormat}
 
     # -- EXPORT
     def to_dict(self) -> dict:

--- a/qgis_deployment_toolbelt/profiles/rules_context.py
+++ b/qgis_deployment_toolbelt/profiles/rules_context.py
@@ -83,6 +83,7 @@ class QdtRulesContext:
         return {
             "computer_network_name": platform.node(),
             "operating_system_code": opersys,
+            "operating_system_release": platform.release(),
             "processor_architecture": platform.machine(),
             # custom Linux
             "linux_distribution_name": linux_distribution_name,

--- a/qgis_deployment_toolbelt/utils/user_groups.py
+++ b/qgis_deployment_toolbelt/utils/user_groups.py
@@ -23,16 +23,10 @@ if opersys == "win32":
     """windows"""
 
     # 3rd party
+    import pyad
     import win32com
     import win32net
     from pywintypes import error as PyWinException
-
-    # try to import pyad
-    try:
-        import pyad
-    except ImportError:
-        logging.info("'pyad' package is not available.")
-        pyad = None
 
 else:
     import grp


### PR DESCRIPTION
This PR follows the 0.34 release to extend information when QDT is run in a Windows domain. Sample output:

```json
{
    "date": {
        "current_day": 24,
        "current_month": 4,
        "current_weekday": 2,
        "current_year": 2024
    },
    "environment": {
        "computer_network_name": "VM200145",
        "linux_distribution_name": null,
        "linux_distribution_version": null,
        "operating_system_code": "win32",
        "operating_system_release": "10",
        "processor_architecture": "AMD64",
        "windows_edition": "Professional"
    },
    "user": {
        "groups_domain": [
            "GGD_FONC_HENRY-TMA",
            "GGD_ORGA_INTERVENANTS",
            "GGD_ORG_DG-HENRY_DES",
            "GGD_ORG_DG_TOUS",
            "GGD_SCM_PMAD-SI",
            "GGD_WIFI_AGENTS_TOUS",
            "GG_INSTALL_SAGE_EAU",
            "METROPOLIS_TOUS",
            "SITE_DOMICILE-BUREAU_SOCIETE_EXTERNE",
            "Tous_DDR",
            "Tous_HENRY",
            "Tous_HENRY_DINSI"
        ],
        "groups_local": [],
        "name": "ICHIGO",
        "windows_extended": {
            "NameCanonical": "bah.lady.glue/PERSONNES/METROPOLIS/HENRY/INTERVENANTS/ICHIGO",
            "NameCanonicalEx": "bah.lady.glue/PERSONNES/METROPOLIS/HENRY/INTERVENANTS\nICHIGO",
            "NameDisplay": "Julien M.",
            "NameDnsDomain": "bah.lady.glue\\ICHIGO",
            "NameFullyQualifiedDN": "CN=ICHIGO,OU=INTERVENANTS,OU=HENRY,OU=METROPOLIS,OU=PERSONNES,DC=ben,DC=oscar,DC=glue",
            "NameGivenName": "",
            "NameSamCompatible": "BEN\\ICHIGO",
            "NameServicePrincipal": "",
            "NameSurname": "",
            "NameUniqueId": "{123-2820-44s5b7-4654-5sbqeq5xcqx9qsbf}",
            "NameUnknown": "",
            "NameUserPrincipal": "ext.oslandia.julienm@tigre.com"
        }
    }
}
```
