### PR TITLE
fix(downloader): qdt_plugins_to_copy was not created in force mode

### DIFF
--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -89,6 +89,7 @@ class JobPluginsDownloader(GenericJob):
         # filter plugins to download, filtering out those which are not already present locally
         if self.options.get("force") is True:
             qdt_plugins_to_download = qdt_referenced_plugins
+            qdt_plugins_to_copy = []
         else:
             qdt_plugins_to_download = self.filter_list_downloadable_plugins(
                 input_list=qdt_referenced_plugins
@@ -216,7 +217,8 @@ class JobPluginsDownloader(GenericJob):
                 performed synchronously. Defaults to 5.
 
         Returns:
-            Tuple[List[QgisPlugin],List[QgisPlugin]]: tuple of (downloaded plugins, failed downloads)
+            Tuple[List[QgisPlugin],List[QgisPlugin]]: tuple of \
+                (downloaded plugins, failed downloads)
         """
         downloaded_plugins: list[QgisPlugin] = []
         failed_plugins: list[QgisPlugin] = []


### PR DESCRIPTION
When `force: true` in plugins downloader job, it was failing because of unbound locale var:


```python
2024-09-04 10:03:43||ERROR||bouncer||exit_cli_error||43||cannot access local variable 'qdt_plugins_to_copy' where it 
is not associated with a value
Traceback (most recent call last):
  File "qgis_deployment_toolbelt\commands\deployment.py", line 207, in run
  File "qgis_deployment_toolbelt\jobs\job_plugins_downloader.py", line 120, in run
UnboundLocalError: cannot access local variable 'qdt_plugins_to_copy' where it is not associated with a value
```