### PR TITLE
fix(proxies): define environment variable for proxy use for git clone

### DIFF
--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -28,6 +28,7 @@ from giturlparse import parse as git_parse
 from giturlparse import validate as git_validate
 
 # project
+from qgis_deployment_toolbelt.utils import proxies
 from qgis_deployment_toolbelt.utils.check_path import check_folder_is_empty
 
 # #############################################################################
@@ -223,6 +224,7 @@ class RemoteProfilesHandlerBase:
             )
             return False
 
+    @proxies.os_env_proxy
     def get_active_branch_from_local_repository(
         self, local_git_repository_path: Path | None = None
     ) -> str:
@@ -302,6 +304,7 @@ class RemoteProfilesHandlerBase:
             )
         ]
 
+    @proxies.os_env_proxy
     def list_remote_branches(
         self, source_repository_path_or_url: Path | str | None = None
     ) -> tuple[str]:
@@ -351,6 +354,7 @@ class RemoteProfilesHandlerBase:
         else:
             return ("",)
 
+    @proxies.os_env_proxy
     def download(self, destination_local_path: Path) -> Repo:
         """Generic wrapper around the specific logic of this handler.
 
@@ -471,6 +475,7 @@ class RemoteProfilesHandlerBase:
             )
             return None
 
+    @proxies.os_env_proxy
     def _clone(self, local_path: Path) -> Repo:
         """Clone the remote repository to local path.
 
@@ -526,6 +531,7 @@ class RemoteProfilesHandlerBase:
         )
         return repo_obj
 
+    @proxies.os_env_proxy
     def _fetch(self, local_path: Path) -> Repo:
         """Fetch the remote repository from the existing local repository.
 
@@ -564,6 +570,7 @@ class RemoteProfilesHandlerBase:
 
         return destination_local_repository
 
+    @proxies.os_env_proxy
     def _pull(self, local_path: Path) -> Repo:
         """Pull the remote repository from the existing local repository.
 

--- a/qgis_deployment_toolbelt/utils/proxies.py
+++ b/qgis_deployment_toolbelt/utils/proxies.py
@@ -162,7 +162,14 @@ def get_proxy_settings_from_pac_file(
 
 def os_env_proxy(func):
     def wrapper(*args, **kwargs):
-        """Decorator wrapper
+        """Decorator wrapper to define environment variable for proxy use.
+
+        If a proxy settings is available for https or http we:
+        - backup current environment value 
+        - define environment value with proxy settings
+        - run function
+        - restore environment value if available
+        
 
         Returns:
             _type_: function result

--- a/qgis_deployment_toolbelt/utils/proxies.py
+++ b/qgis_deployment_toolbelt/utils/proxies.py
@@ -12,6 +12,7 @@
 
 # Standard library
 import logging
+import os
 from functools import lru_cache
 from os import environ
 from urllib.request import getproxies
@@ -157,6 +158,39 @@ def get_proxy_settings_from_pac_file(
         if environ.get("HTTPS_PROXY"):
             proxy_settings["https"] = environ.get("HTTPS_PROXY")
     return proxy_settings
+
+
+def os_env_proxy(func):
+    def wrapper(*args, **kwargs):
+        """Decorator wrapper
+
+        Returns:
+            _type_: function result
+        """
+        # Get proxy settings
+        proxy_settings = get_proxy_settings()
+
+        # Update environment variable and keep current value
+        prev_http_proxy = None
+        if "http" in proxy_settings:
+            prev_http_proxy = environ.get("HTTP_PROXY")
+            os.environ["HTTP_PROXY"] = proxy_settings["http"]
+        prev_https_proxy = None
+        if "https" in proxy_settings:
+            prev_https_proxy = environ.get("HTTPS_PROXY")
+            os.environ["HTTPS_PROXY"] = proxy_settings["https"]
+
+        # Run function
+        result = func(*args, **kwargs)
+
+        # Restore environment variable if available
+        if prev_http_proxy:
+            os.environ["HTTP_PROXY"] = prev_http_proxy
+        if prev_https_proxy:
+            os.environ["HTTPS_PROXY"] = prev_https_proxy
+        return result
+
+    return wrapper
 
 
 # #############################################################################

--- a/qgis_deployment_toolbelt/utils/proxies.py
+++ b/qgis_deployment_toolbelt/utils/proxies.py
@@ -165,11 +165,11 @@ def os_env_proxy(func):
         """Decorator wrapper to define environment variable for proxy use.
 
         If a proxy settings is available for https or http we:
-        - backup current environment value 
+        - backup current environment value
         - define environment value with proxy settings
         - run function
         - restore environment value if available
-        
+
 
         Returns:
             _type_: function result


### PR DESCRIPTION
When a proxy is needed for git clone, `dulwich` and high level interface `porcelain` only use environment variable for proxy definition : `HTTP_PROXY` / `HTTPS_PROXY`

In this PR we are :
- defining a wrapper for environment variable definition and backup
- use wrapper for all function using porcelain for git command