### PR TITLE
fix(log): limit pyad to 0.6.2 for correct log level

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ imagesize>=1.4,<1.5
 packaging>=20,<25
 pypac>=0.16.3,<1
 python-rule-engine>=0.5,<0.6
-python-win-ad>=0.6.2,<1 ; sys_platform == 'win32'
+python-win-ad==0.6.2 ; sys_platform == 'win32'
 pyyaml>=5.4,<7
 pywin32==308 ; sys_platform == 'win32'
 requests>=2.31,<3


### PR DESCRIPTION
With latest version 0.36.0 of QDT there are no logs display on Windows.

This comes from an update of python-win-ad to 0.6.3 that cause log level of pyad to be used for all python package.

We limit version of python-win-ad to 0.6.2 to restore log display.

closes #585 