### PR TITLE
feat(plugin download): add application/x-zip-compressed for header Accept

### DIFF
--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -236,7 +236,7 @@ class JobPluginsDownloader(GenericJob):
                     download_remote_file_to_local(
                         local_file_path=plugin_download_path,
                         remote_url_to_download=plugin.download_url,
-                        content_type="application/zip, application/x-zip-compressed",
+                        content_type="application/zip, application/x-zip-compressed, application/octet-stream, multipart/x-zip",
                         use_stream=str2bool(getenv("QDT_STREAMED_DOWNLOADS", True)),
                     )
                     logger.info(

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -271,7 +271,7 @@ class JobPluginsDownloader(GenericJob):
                             # func parameters
                             local_file_path=plugin_download_path,
                             remote_url_to_download=plugin.download_url,
-                            content_type="application/zip, application/x-zip-compressed",
+                            content_type="application/zip, application/x-zip-compressed, application/octet-stream, multipart/x-zip",
                             use_stream=str2bool(getenv("QDT_STREAMED_DOWNLOADS", True)),
                         )
                         downloaded_plugins.append(plugin)

--- a/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_downloader.py
@@ -236,7 +236,7 @@ class JobPluginsDownloader(GenericJob):
                     download_remote_file_to_local(
                         local_file_path=plugin_download_path,
                         remote_url_to_download=plugin.download_url,
-                        content_type="application/zip",
+                        content_type="application/zip, application/x-zip-compressed",
                         use_stream=str2bool(getenv("QDT_STREAMED_DOWNLOADS", True)),
                     )
                     logger.info(
@@ -271,7 +271,7 @@ class JobPluginsDownloader(GenericJob):
                             # func parameters
                             local_file_path=plugin_download_path,
                             remote_url_to_download=plugin.download_url,
-                            content_type="application/zip",
+                            content_type="application/zip, application/x-zip-compressed",
                             use_stream=str2bool(getenv("QDT_STREAMED_DOWNLOADS", True)),
                         )
                         downloaded_plugins.append(plugin)


### PR DESCRIPTION
Some server might not consider plugin .zip as `application/zip` but `application/x-zip-compressed`. 

In this case, the server doesn't return the plugin .zip but an error page.

In this PR we add `application/x-zip-compressed` to the header `Accept` to fix this issue.