### PR TITLE
update(ci): split release creation in two steps to comply with Immutable Releases

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -217,13 +217,20 @@ jobs:
           name: windows_executable
           path: builds/windows/
 
-      - name: Release
+      - name: Upload draft Artifacts
         uses: softprops/action-gh-release@v2
         with:
-          discussion_category_name: announcements
+          draft: true
           fail_on_unmatched_files: true
           files: builds/*/dist/*
           generate_release_notes: true
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          discussion_category_name: announcements
+
 
   release-pypi:
     name: "🐍 Release on PyPI"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ Because QDT is meant to be carried out on large-scale IT infrastructures, securi
 
 - [GitGuardian](https://www.gitguardian.com/): detects secrets in the source code to help developers and security teams secure the modern development process.
 - [Github Code QL](https://codeql.github.com/): GitHub integrated tool to discover vulnerabilities across a codebase
+- [GitHub Immutable Releases](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
 - [Dependabot Alerts](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-supply-chain-security#what-is-dependabot): GitHub integrated tool that keeps dependencies up to date by informing of any security vulnerabilities in project's dependencies, and automatically opens pull requests to upgrade dependencies to the next available secure version when a Dependabot alert is triggered, or to the latest version when a release is published.
 - [GitHub secret scanning](https://docs.github.com/code-security/secret-scanning/secret-scanning-patterns#supported-secrets): integrated Github secrets scanning to receive alerts for detected secrets, keys, or other tokens.
 - [Bandit](https://bandit.readthedocs.io): Bandit is a tool designed to find common security issues in Python code. Aslo executed for every commit as git hook.


### PR DESCRIPTION
see: https://docs.github.com/fr/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases

and https://github.com/softprops/action-gh-release/issues/653