### PR TITLE
improve(ci): move GH Token permissions to job level

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,22 +31,18 @@ on:
 
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  id-token: write
-  pages: write
-
 jobs:
   build-docs:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
       - name: Get source code
         uses: actions/checkout@v6
         with:
-            fetch-depth: 0
-            fetch-tags: true
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -95,6 +91,9 @@ jobs:
 
   deploy-docs:
     needs: build-docs
+    permissions:
+      id-token: write
+      pages: write
     runs-on: ubuntu-latest
     if: ${{
       (github.event_name == 'push' &&


### PR DESCRIPTION
See: https://sonarcloud.io/project/issues?severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&types=VULNERABILITY&pullRequest=747&id=Guts_qgis-deployment-cli&open=AZt4yoTbv37Do7seUtsL