### PR TITLE
improve(ci): move GH Token permissions to job level

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,14 +34,12 @@ env:
   PYTHON_VERSION: "3.12"
   PYINSTALLER_LOG_LEVEL: "DEBUG"
 
-# Sets permissions of the GITHUB_TOKEN
-permissions:
-  contents: read
-
 # Jobs definition
 jobs:
   build-python-wheel:
     name: "🐍 Python Wheel"
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
 
     steps:
@@ -84,6 +82,8 @@ jobs:
 
   build-macos:
     name: "🍏 Mac OS"
+    permissions:
+      contents: read
     runs-on: macos-15
 
     steps:
@@ -121,6 +121,8 @@ jobs:
 
   build-ubuntu:
     name: "🐧 Ubuntu LTS"
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
 
     steps:
@@ -157,6 +159,8 @@ jobs:
 
   build-windows:
     name: "🏠 Windows"
+    permissions:
+      contents: read
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,14 +28,12 @@ env:
   PROJECT_FOLDER: "qgis_deployment_toolbelt"
   PYTHON_VERSION: "3.13"
 
-# Sets permissions of the GITHUB_TOKEN
-permissions:
-  contents: read
-
 # Jobs definition
 jobs:
   check-bandit:
     name: "🦹‍♂️ Bandit"
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -60,6 +58,8 @@ jobs:
 
   check-safety:
     name: "🛡 Safety PyUp"
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.repository.fork != true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,10 @@ concurrency:
 env:
   PROJECT_FOLDER: "qgis_deployment_toolbelt"
 
-# Sets permissions of the GITHUB_TOKEN
-permissions:
-  contents: read
-
 jobs:
   unit-test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       # max-parallel: 4
@@ -86,6 +84,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration-test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       # max-parallel: 4


### PR DESCRIPTION
Follow-up of https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/751