### PR TITLE
feat(jobs): add new job `qglobal-config-manager` for qgis_global_settings.ini copy

### DIFF
--- a/docs/jobs/index.md
+++ b/docs/jobs/index.md
@@ -13,6 +13,7 @@ plugins_downloader.md
 plugins_synchronizer.md
 profiles_downloader.md
 profiles_synchronizer.md
+qglobal_config_manager.md
 shortcuts_manager.md
 splash_screen_manager.md
 *

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -35,6 +35,8 @@ This can be an url, in this case, QDT download the .ini file in a local director
     - .ini file can be stored in profile repository and defined with a relative `src` : `./myprofile/qgis_global_settings.ini`
 - qdt local working directory.
     - can be defined with `QDT_LOCAL_WORK_DIR` environment variable
+- qdt run directory.
+    - path can be relative to the current directory where qdt is launched
 
 The job fails if source .ini file doesn't exist or can't be downloaded.
 

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -24,7 +24,9 @@ Sample job configuration in your scenario file:
 
 ### src
 
-Define source .ini file path. This can be an url, in this case, QDT download the .ini file in a local directory before copying to the destination.
+Define source .ini file path. You can use environment variable that will be converted before use.
+
+This can be an url, in this case, QDT download the .ini file in a local directory before copying to the destination.
 
 `src` can be a relative path. In this case we check for .ini file related to:
 
@@ -38,7 +40,9 @@ The job fails if source .ini file doesn't exist or can't be downloaded.
 
 ### dst
 
-Define destination .ini file path. The file path must be absolute.
+Define destination .ini file path. You can use environment variable that will be converted before use.
+
+The file path must be absolute.
 
 If the source .ini file use environment variables, they are converted in destination .ini file.
 

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -70,3 +70,12 @@ If no value defined in jobs, default values are used. The value is defined with 
 1. Check `src` definition (use default value / download from url / check if exists)
 1. Copy `src` .ini file to `dst` .ini with environment variable conversion
 1. Update `QGIS_GLOBAL_SETTINGS_FILE` environment variable with `dst` .ini file path
+
+----
+
+## Schema
+
+```{eval-rst}
+.. literalinclude:: ../schemas/scenario/jobs/qglobal-config-manager.json
+  :language: json
+```

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -1,0 +1,66 @@
+# QGIS global config manager
+
+[`qgis_global_settings.ini` file](https://docs.qgis.org/latest/en/docs/user_manual/introduction/qgis_configuration.html#globalsettingsfile) contains global settings for all QGIS profile.
+
+This jobs handles copy of a source .ini file to a destination .ini file and definition of `QGIS_GLOBAL_SETTINGS_FILE` environment variable so the file can be used by QGIS.
+
+----
+
+## Use it
+
+Sample job configuration in your scenario file:
+
+```yaml
+  - name: Handle the qgis_global_settings.ini file
+    uses: qglobal-config-manager
+    with:
+      src: ./global/qgis_global_settings.ini
+      dst: ~/config/qgis/global_settings.ini
+```
+
+----
+
+## Options
+
+### src
+
+Define source .ini file path. This can be an url, in this case, QDT download the .ini file in a local directory before copying to the destination.
+
+`src` can be a relative path. In this case we check for .ini file related to:
+
+- repository folder from current scenario
+    - when the job `qprofiles-synchronizer` is run, all profiles repository are stored in a local repositories folder : `<qdt_working_folder>/respositories/<scenario_id>`
+    - .ini file can be stored in profile repository and defined with a relative `src` : `./myprofile/qgis_global_settings.ini`
+- qdt local working directory.
+    - can be defined with `QDT_LOCAL_WORK_DIR` environment variable
+
+The job fails if source .ini file doesn't exist or can't be downloaded.
+
+### dst
+
+Define destination .ini file path. The file path must be absolute.
+
+If the source .ini file use environment variables, they are converted in destination .ini file.
+
+## Default value
+
+If no value defined in jobs, default values are used. The value is defined with the same behavior as QGIS :
+
+- first use `QGIS_GLOBAL_SETTINGS_FILE`
+- if not defined, use AppDataLocation folder:
+    - Linux: `$HOME/.local/share/QGIS/QGIS3/`
+    - Windows  : `C:\Users\<username>\%AppData%\Roaming\QGIS\QGIS3\`
+    - MacOS : `$HOME/Library/Application Support/QGIS/QGIS3/`
+- if file doesn't exists :
+    - the installation directory, i.e.,  `your_QGIS_package_path/resources/qgis_global_settings.ini`
+    - to define the QGIS package path we use `QDT_QGIS_EXE_PATH` environment variable
+
+----
+
+## How does it work
+
+### Workflow
+
+1. Check `src` definition (use default value / download from url / check if exists)
+1. Copy `src` .ini file to `dst` .ini with environment variable conversion
+1. Update `QGIS_GLOBAL_SETTINGS_FILE` environment variable with `dst` .ini file path

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -18,6 +18,16 @@ Sample job configuration in your scenario file:
       dst: ~/config/qgis/global_settings.ini
 ```
 
+Using a remote file accessible by end-user computer through HTTP(S):
+
+```yaml
+  - name: Deploy qgis_global_settings.ini from HTTP server
+    uses: qglobal-config-manager
+    with:
+      src: https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/feat/qglobal_config_manager/examples/global_config/qgis_global_settings.ini
+      dst: ~/config/qgis/global_settings.ini
+```
+
 ----
 
 ## Options

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -2,7 +2,7 @@
 
 [`qgis_global_settings.ini` file](https://docs.qgis.org/latest/en/docs/user_manual/introduction/qgis_configuration.html#globalsettingsfile) contains global settings for all QGIS profile.
 
-This jobs handles copy of a source .ini file to a destination .ini file and definition of `QGIS_GLOBAL_SETTINGS_FILE` environment variable so the file can be used by QGIS.
+This jobs copies/downloads a source .ini file to a destination .ini file and defines the `QGIS_GLOBAL_SETTINGS_FILE` environment variable to make it taken in account by QGIS.
 
 ----
 
@@ -26,17 +26,15 @@ Sample job configuration in your scenario file:
 
 Define source .ini file path. You can use environment variable that will be converted before use.
 
-This can be an url, in this case, QDT download the .ini file in a local directory before copying to the destination.
+This can be an url, in this case, QDT will download the remote .ini file in a local directory before copying to the destination.
 
 `src` can be a relative path. In this case we check for .ini file related to:
 
 - repository folder from current scenario
-    - when the job `qprofiles-synchronizer` is run, all profiles repository are stored in a local repositories folder : `<qdt_working_folder>/respositories/<scenario_id>`
-    - .ini file can be stored in profile repository and defined with a relative `src` : `./myprofile/qgis_global_settings.ini`
-- qdt local working directory.
-    - can be defined with `QDT_LOCAL_WORK_DIR` environment variable
-- qdt run directory.
-    - path can be relative to the current directory where qdt is launched
+    - when the job `qprofiles-synchronizer` is run, all profiles repository are stored in a local repositories folder: `<qdt_working_folder>/repositories/<scenario_id>`
+    - .ini file can be stored in profile repository and defined with a relative `src`: `./myprofile/qgis_global_settings.ini`
+- QDT local working directory which can be defined with `QDT_LOCAL_WORK_DIR` environment variable
+- QDT run directory: path can be relative to the current directory where QDT is launched
 
 The job fails if source .ini file doesn't exist or can't be downloaded.
 
@@ -46,19 +44,19 @@ Define destination .ini file path. You can use environment variable that will be
 
 The file path must be absolute.
 
-If the source .ini file use environment variables, they are converted in destination .ini file.
+As every QGIS ini file processed by QDT, if the source .ini file contains environment variables, they are interpolated in destination .ini file.
 
 ## Default value
 
-If no value defined in jobs, default values are used. The value is defined with the same behavior as QGIS :
+If no value defined in jobs, default values are used. The value is defined with the same behavior as QGIS:
 
-- first use `QGIS_GLOBAL_SETTINGS_FILE`
-- if not defined, use AppDataLocation folder:
+1. first use `QGIS_GLOBAL_SETTINGS_FILE`
+2. if not defined, use AppDataLocation folder:
     - Linux: `$HOME/.local/share/QGIS/QGIS3/`
-    - Windows  : `C:\Users\<username>\%AppData%\Roaming\QGIS\QGIS3\`
-    - MacOS : `$HOME/Library/Application Support/QGIS/QGIS3/`
-- if file doesn't exists :
-    - the installation directory, i.e.,  `your_QGIS_package_path/resources/qgis_global_settings.ini`
+    - Windows: `%AppData%\Roaming\QGIS\QGIS3\`
+    - MacOS: `$HOME/Library/Application Support/QGIS/QGIS3/`
+3. if file doesn't exists:
+    - the installation directory, i.e., `your_QGIS_package_path/resources/qgis_global_settings.ini`
     - to define the QGIS package path we use `QDT_QGIS_EXE_PATH` environment variable
 
 ----

--- a/docs/jobs/qglobal_config_manager.md
+++ b/docs/jobs/qglobal_config_manager.md
@@ -18,6 +18,16 @@ Sample job configuration in your scenario file:
       dst: ~/config/qgis/global_settings.ini
 ```
 
+Using environment variables:
+
+```yaml
+  - name: Deploy qgis_global_settings.ini from HTTP server
+    uses: qglobal-config-manager
+    with:
+      src: "%APPDATA%/QDT/config/qgis_global_settings.ini"
+      dst: "%APPDATA%/QGIS/qgis_global_settings.ini"
+```
+
 Using a remote file accessible by end-user computer through HTTP(S):
 
 ```yaml

--- a/docs/schemas/scenario/jobs/qdt_job_base.json
+++ b/docs/schemas/scenario/jobs/qdt_job_base.json
@@ -30,6 +30,7 @@
           "qplugins-synchronizer",
           "qprofiles-downloader",
           "qprofiles-synchronizer",
+          "qglobal-config-manager",
           "qprofiles-manager",
           "shortcuts-manager",
           "splash-screen-manager"
@@ -104,6 +105,16 @@
           },
           "with": {
             "$ref": "qprofiles-synchronizer.json"
+          }
+        }
+      },
+      {
+        "properties": {
+          "uses": {
+            "const": "qglobal-config-manager"
+          },
+          "with": {
+            "$ref": "qglobal-config-manager.json"
           }
         }
       },

--- a/docs/schemas/scenario/jobs/qglobal-config-manager.json
+++ b/docs/schemas/scenario/jobs/qglobal-config-manager.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/jobs/qglobal-config-manager.json",
+  "description": "This jobs handles copy of a source .ini file to a destination .ini file and definition of `QGIS_GLOBAL_SETTINGS_FILE` environment variable so the file can be used by QGIS.",
+  "title": "QGIS global config manager",
+  "type": "object",
+  "properties": {
+    "src": {
+      "description": "Source .ini file path. Can use environment variable that will be converted before use.",
+      "type": "string"
+    },
+    "dst": {
+      "description": "Destination .ini file path. Can use environment variable that will be converted before use.",
+      "type": "string"
+    }
+  }
+}

--- a/examples/global_config/qgis_global_settings.ini
+++ b/examples/global_config/qgis_global_settings.ini
@@ -1,0 +1,281 @@
+[qgis]
+
+# If true, QGIS will automatically check for new versions on startup and notify users if a new version is available.
+# This setting controls the default value for that setting. Users may still manually enable or disable this check
+# through the QGIS settings dialog.
+checkVersion=true
+
+# If true, users may control whether the version check is enabled or disabled through the QGIS settings dialog. (The default
+# check behavior is determined by the 'checkVersion' setting). If false, no version checking will be performed and
+# users will NOT have an option to enable this check in the settings dialog.
+# This setting is intended for use in enterprise installs where QGIS version management is handled centrally.
+allowVersionCheck=true
+
+# If true, added layer names will be automatically capitalized and underscores replaced with spaces
+formatLayerName=false
+
+# If set to true then directories will be automatically monitored and refreshed when their contents change outside of QGIS.
+# This monitoring can be expensive, especially for remote or network drives, in which case setting this option to false
+# can result in a speedup of the QGIS interface.
+monitorDirectoriesInBrowser=true
+
+[digitizing]
+
+# Snapping enabled by default
+default-snap-enabled=false
+
+# Default snapping tolerance (distance)
+default-snapping-tolerance=12.0
+
+# Default snap to type
+# Vertex, VertexAndSegment, Segment
+default-snap-type=Vertex
+
+# Default snapping unit
+# LayerUnits, Pixels, ProjectUnits
+default-snapping-tolerance-unit=Pixels
+
+# Snap on invisible feature
+snap-invisible-feature=false
+
+[connections]
+
+# Default XYZ tile servers to include
+xyz\items\OpenStreetMap\authcfg=
+xyz\items\OpenStreetMap\password=
+xyz\items\OpenStreetMap\referer=
+xyz\items\OpenStreetMap\url=https://tile.openstreetmap.org/{z}/{x}/{y}.png?{usage}
+xyz\items\OpenStreetMap\username=
+xyz\items\OpenStreetMap\zmax=19
+xyz\items\OpenStreetMap\zmin=0
+xyz\items\OpenStreetMap\tile-pixel-ratio=1
+
+xyz\items\Mapzen Global Terrain\authcfg=
+xyz\items\Mapzen Global Terrain\password=
+xyz\items\Mapzen Global Terrain\referer=
+xyz\items\Mapzen Global Terrain\url=https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png?{usage}
+xyz\items\Mapzen Global Terrain\username=
+xyz\items\Mapzen Global Terrain\zmax=15
+xyz\items\Mapzen Global Terrain\zmin=0
+xyz\items\Mapzen Global Terrain\interpretation=terrariumterrain
+
+xyz\items\Plan IGN\authcfg=
+xyz\items\Plan IGN\password=
+xyz\items\Plan IGN\referer=
+xyz\items\Plan IGN\url=https://data.geopf.fr/tms/1.0.0/GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2/{z}/{x}/{y}.png
+xyz\items\Plan IGN\username=
+xyz\items\Plan IGN\zmax=15
+xyz\items\Plan IGN\zmin=0
+
+[qgis]
+
+# The image format selected by default when adding a WMS, i.e. image/png. If empty, the first available format is used
+WMSDefaultFormat=""
+
+# application stylesheet
+
+# Padding (in pixels) to add to toolbar icons, if blank then default padding will be used
+stylesheet\toolbarSpacing=
+
+# If true, new projects are using relative paths. If false, new projects default to absolute paths.
+defaultProjectPathsRelative=true
+
+# Max image cache size in bytes.
+# The cache is used for caching symbology and layout images,
+# If high resolution images are used for printing layout, then this
+# value should be increased accordingly.
+# If 0, will use a default value calculated based on the system memory (which defaults to 100mb)
+maxImageCacheSize=0
+
+[app]
+
+# Whether the user should be asked to save a layer in case of one or more MemoryLayers
+# when a project is closed.
+# Default to true, set to false to disable this dialog/question.
+askToSaveMemoryLayers=true
+
+# Maximum number of recent projects to show on the welcome page
+maxRecentProjects=20
+
+# Minimum time (in seconds) for a background task to execute in order for a system
+# notification to be shown when the task completes.
+minTaskLengthForSystemNotification=5
+
+# Whether to show the distance panned message in the status bar after a map pan operation
+# occurs. Set to false to disable the message.
+showPanDistanceInStatusBar=true
+
+# Whether to prompt users for a selection when multiple possible transformation paths exist
+# when transforming coordinates. If false, a reasonable choice will be estimated by default
+# without asking users. If true, users are always required to make this choice themselves.
+projections\promptWhenMultipleTransformsExist=true
+
+# Default CRS for newly created projects. Accepts "auth:code" style strings (e.g. EPSG:4326),
+# PROJ strings (must be prefixed with PROJ4:, e.g. "PROJ4:+proj ...."), or WKT strings (must
+# be prefixed with WKT:, e.g. "WKT:<wkt string>")
+# This is only used when projections\newProjectCrsBehavior is set to UsePresetCrs
+projections\defaultProjectCrs=EPSG:4326
+
+# Specifies the method to set the CRS for a newly created project. Valid options are
+# "UseCrsOfFirstLayerAdded" - sets the project CRS to match the CRS of the first layer added to the project
+# "UsePresetCrs" - always use a preset CRS, see projections\defaultProjectCrs
+projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
+
+# Specifies the behavior when adding a layer with unknown/invalid CRS to a project
+# "NoAction" - take no action and leave as unknown CRS
+# "PromptUserForCrs" - user is prompted for a CRS choice
+# "UseProjectCrs" - copy the current project's CRS
+# "UseDefaultCrs" - use the default layer CRS set via QGIS options
+projections\unknownCrsBehavior=NoAction
+
+# If the inherent inaccuracy in a selected CRS exceeds this threshold value (in meters),
+# a warning message will be shown to the user advising them to select an alternative
+# CRS if higher positional accuracy is required
+projections\crsAccuracyWarningThreshold=0.0
+
+# If set to true, a warning icon will be shown next to any layer where the layer's CRS exceeds
+# the accuracy warning threshold value (see crsAccuracyWarningThreshold)
+projections\crsAccuracyIndicator=false
+
+[app]
+
+# Specifies a manual bearing correction to apply to bearings reported by a GPS
+# device, for use when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\bearingAdjustment=0
+
+# Set to "true" to automatically correct GPS reported bearings for true north
+# when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\correctForTrueNorth=false
+
+
+[gps]
+
+# Desired flow control mode for serial port GPS connections
+# "NoFlowControl" - no flow control
+# "HardwareControl" - hardware flow control (RTS/CTS)
+# "SoftwareControl" - software flow control (XON/XOFF)
+flow-control=NoFlowControl
+
+# Desired parity checking mode for serial port GPS connections
+# "NoParity" - No parity bit it sent. This is the most common parity setting. Error detection is handled by the communication protocol.
+# "EvenParity" - The number of 1 bits in each character, including the parity bit, is always even.
+# "OddParity" - The number of 1 bits in each character, including the parity bit, is always odd. It ensures that at least one state transition occurs in each character.
+# "SpaceParity" - Space parity. The parity bit is sent in the space signal condition. It does not provide error detection information.
+# "MarkParity" - Mark parity. The parity bit is always set to the mark signal condition (logical 1). It does not provide error detection information.
+parity=NoParity
+
+# Desired data bits in a frame for serial port GPS connections
+# "Data5" - The number of data bits in each character is 5. It is used for Baudot code. It generally only makes sense with older equipment such as teleprinters.
+# "Data6" - The number of data bits in each character is 6. It is rarely used.
+# "Data7" - The number of data bits in each character is 7. It is used for true ASCII. It generally only makes sense with older equipment such as teleprinters.
+# "Data8" - The number of data bits in each character is 8. It is used for most kinds of data, as this size matches the size of a byte. It is almost universally used in newer applications.
+data-bits=Data8
+
+# Desired number of stop bits in a frame for serial port GPS connections
+# "OneStop" - 1 stop bit.
+# "OneAndHalfStop" - 1.5 stop bits. This is only for the Windows platform.
+# "TwoStop" - 2 stop bits.
+stop-bits=OneStop
+
+# Default for GPS leap seconds correction as of 2019-06-19
+leapSecondsCorrection=18
+
+[core]
+
+# Whether or not to anonymize newly created projects
+# If set to true, then project metadata items like AUTHOR and CREATION DATE
+# will not be automatically populated when a new project is created.
+projects\anonymize_new_projects=false
+
+# Whether or not to anonymize projects when saving
+# If set to true, then username information will not be stored in saved projects
+projects\anonymize_saved_projects=false
+
+# News feed settings
+# Set to true to disable the QGIS news feed on the welcome page
+NewsFeed\http00008000\disabled=false
+
+# Optionally, set to an ISO-939-1 two letter language code to filter the QGIS news feed by language
+NewsFeed\http00008000\lang=
+
+# Optionally, set to a specific user latitude and longitude to filter the QGIS news feed to remove
+# local news outside of the users geographic area
+NewsFeed\http00008000\lat=
+NewsFeed\http00008000\long=
+
+# When new projects are created, default to planimetric measurement.
+measure\planimetric=false
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for point features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_points=0
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for line features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_lines=0
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for polygon features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_polygons=0
+
+[colors]
+# These colors are used in logs.
+default=
+info=
+success=
+warning=#dc7d00
+critical=#c80000
+
+[help]
+# Default help location to include
+# for now this is online version of the User Guide for latest (LTR) release
+helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_manual/
+
+[providers]
+# Whether deprecated data providers should be shown in the QGIS UI (e.g. db2)
+# Warning: these providers are NOT supported and they will be dropped in a future QGIS
+# version. Commercial users requiring on these providers should contact the QGIS
+# project ASAP and arrange for ongoing funding of the provider to prevent their
+# removal and restore them to fully supported status.
+showDeprecated=false
+
+# Default timeout for PostgreSQL servers (seconds)
+PostgreSQL\default_timeout=30
+
+[gui]
+# Maximum number of entries to show in Relation Reference widgets. Too large a number here can
+# cause performance issues, as the records must all be loaded from the related table on display.
+maxEntriesRelationWidget=100
+
+# Path to default image to use for layout north arrows
+# Acceptable formats include local paths, http(s) urls, or even base64 encoded SVGs (prefixed with base64:....)
+LayoutDesigner\defaultNorthArrow=:/images/north_arrows/layout_default_north_arrow.svg
+
+# Default font to use in layout designer
+LayoutDesigner\defaultFont=
+
+[geometry_validation]
+# A comma separated list of geometry validations to enable by default for newly added layers
+# Available checks: QgsIsValidCheck,QgsGeometryGapCheck,QgsGeometryOverlapCheck,QgsGeometryMissingVertexCheck
+default_checks=
+
+# Enable problem resolution for geometry errors
+# This feature is experimental and has known issues.
+enable_problem_resolution=false
+
+
+# Path to (or command name for) the GPSBabel executable file
+gpsbabelPath=gpsbabel
+
+[proxy]
+# # URL list for which proxy configuration doesn't apply. In the case of these URLs, the default system proxy configuration
+# # is applied
+# proxyExcludedUrls=http://intranet,http://anotherproxy

--- a/examples/global_config/qgis_global_settings.ini
+++ b/examples/global_config/qgis_global_settings.ini
@@ -3,13 +3,13 @@
 # If true, QGIS will automatically check for new versions on startup and notify users if a new version is available.
 # This setting controls the default value for that setting. Users may still manually enable or disable this check
 # through the QGIS settings dialog.
-checkVersion=true
+checkVersion=false
 
 # If true, users may control whether the version check is enabled or disabled through the QGIS settings dialog. (The default
 # check behavior is determined by the 'checkVersion' setting). If false, no version checking will be performed and
 # users will NOT have an option to enable this check in the settings dialog.
 # This setting is intended for use in enterprise installs where QGIS version management is handled centrally.
-allowVersionCheck=true
+allowVersionCheck=false
 
 # If true, added layer names will be automatically capitalized and underscores replaced with spaces
 formatLayerName=false
@@ -22,7 +22,7 @@ monitorDirectoriesInBrowser=true
 [digitizing]
 
 # Snapping enabled by default
-default-snap-enabled=false
+default-snap-enabled=true
 
 # Default snapping tolerance (distance)
 default-snapping-tolerance=12.0
@@ -99,7 +99,7 @@ maxRecentProjects=20
 
 # Minimum time (in seconds) for a background task to execute in order for a system
 # notification to be shown when the task completes.
-minTaskLengthForSystemNotification=5
+minTaskLengthForSystemNotification=30
 
 # Whether to show the distance panned message in the status bar after a map pan operation
 # occurs. Set to false to disable the message.
@@ -114,7 +114,7 @@ projections\promptWhenMultipleTransformsExist=true
 # PROJ strings (must be prefixed with PROJ4:, e.g. "PROJ4:+proj ...."), or WKT strings (must
 # be prefixed with WKT:, e.g. "WKT:<wkt string>")
 # This is only used when projections\newProjectCrsBehavior is set to UsePresetCrs
-projections\defaultProjectCrs=EPSG:4326
+projections\defaultProjectCrs=EPSG:2154
 
 # Specifies the method to set the CRS for a newly created project. Valid options are
 # "UseCrsOfFirstLayerAdded" - sets the project CRS to match the CRS of the first layer added to the project
@@ -198,7 +198,7 @@ projects\anonymize_saved_projects=false
 NewsFeed\http00008000\disabled=false
 
 # Optionally, set to an ISO-939-1 two letter language code to filter the QGIS news feed by language
-NewsFeed\http00008000\lang=
+NewsFeed\http00008000\lang=fr
 
 # Optionally, set to a specific user latitude and longitude to filter the QGIS news feed to remove
 # local news outside of the users geographic area
@@ -245,7 +245,7 @@ helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_
 # version. Commercial users requiring on these providers should contact the QGIS
 # project ASAP and arrange for ongoing funding of the provider to prevent their
 # removal and restore them to fully supported status.
-showDeprecated=false
+showDeprecated=true
 
 # Default timeout for PostgreSQL servers (seconds)
 PostgreSQL\default_timeout=30
@@ -253,7 +253,7 @@ PostgreSQL\default_timeout=30
 [gui]
 # Maximum number of entries to show in Relation Reference widgets. Too large a number here can
 # cause performance issues, as the records must all be loaded from the related table on display.
-maxEntriesRelationWidget=100
+maxEntriesRelationWidget=50
 
 # Path to default image to use for layout north arrows
 # Acceptable formats include local paths, http(s) urls, or even base64 encoded SVGs (prefixed with base64:....)
@@ -265,7 +265,7 @@ LayoutDesigner\defaultFont=
 [geometry_validation]
 # A comma separated list of geometry validations to enable by default for newly added layers
 # Available checks: QgsIsValidCheck,QgsGeometryGapCheck,QgsGeometryOverlapCheck,QgsGeometryMissingVertexCheck
-default_checks=
+default_checks=QgsIsValidCheck,QgsGeometryGapCheck
 
 # Enable problem resolution for geometry errors
 # This feature is experimental and has known issues.

--- a/examples/scenarios/demo-scenario-global-config.qdt.yml
+++ b/examples/scenarios/demo-scenario-global-config.qdt.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/main/docs/schemas/scenario/qdt_scenario.json
+
+metadata:
+  title: "Demonstration scenario of QGIS Deployment Toolbelt, with update of QGIS settings for all profiles"
+  id: qdt-demo-scenario-global-config
+  description: >-
+    Demonstration scenario of QGIS Deployment Toolbelt capabilities, with update of QGIS settings for all profiles.
+
+# Toolbelt settings
+settings:
+  # LOCAL_WORK_DIR: ~/.cache/qgis-deployment-toolbelt/demo/
+  # QGIS_EXE_PATH:
+  #   linux: /usr/bin/qgis
+  #   mac: /usr/bin/qgis
+  #   windows: "%PROGRAMFILES%/QGIS/3_28/bin/qgis-ltr-bin.exe"
+  SCENARIO_VALIDATION: true
+
+# Deployment workflow, step by step
+steps:
+  - name: Find installed QGIS
+    uses: qgis-installation-finder
+    with:
+      version_priority:
+        - "3.40"
+        - "3.34"
+        - "3.28"
+        - "3.38"
+        - "3.36"
+        - "3.32"
+      search_paths:
+        - "%PROGRAMFILES%/QGIS"
+      if_not_found: warning
+
+  - name: Download profiles from remote git repository
+    uses: qprofiles-downloader
+    with:
+      source: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli.git
+      protocol: git_remote
+      branch: feat/qglobal_config_manager
+
+  - name: Download profiles from remote git repository
+    uses: qprofiles-synchronizer
+    with:
+      sync_mode: overwrite
+
+  - name: Download plugins
+    uses: qplugins-downloader
+    with:
+      force: false
+      threads: 5
+
+  - name: Synchronize plugins
+    uses: qplugins-synchronizer
+    with:
+      action: create_or_restore
+
+  - name: Handle the qgis_global_settings.ini file (applied for all profiles)
+    uses: qglobal-config-manager
+    with:
+      src: ./examples/global_config/qgis_global_settings.ini

--- a/examples/scenarios/demo-scenario-global-config.qdt.yml
+++ b/examples/scenarios/demo-scenario-global-config.qdt.yml
@@ -21,6 +21,8 @@ steps:
     uses: qgis-installation-finder
     with:
       version_priority:
+        - "3.44"
+        - "4.2"
         - "3.40"
         - "3.34"
         - "3.28"
@@ -36,7 +38,7 @@ steps:
     with:
       source: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli.git
       protocol: git_remote
-      branch: feat/qglobal_config_manager
+      branch: main
 
   - name: Download profiles from remote git repository
     uses: qprofiles-synchronizer

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -287,7 +287,9 @@ class OSConfiguration:
 
         # Check if file exists
         if default_file_path:
-            if check_exists and default_file_path.exists():
+            if not check_exists:
+                return default_file_path
+            elif default_file_path.exists():
                 return default_file_path
 
         # Define from qgis bin path
@@ -297,8 +299,11 @@ class OSConfiguration:
                 Path(qgis_bin_path).parent / "resources" / "qgis_global_settings.ini"
             )
 
-        if check_exists and default_file_path.exists():
-            return default_file_path
+        if default_file_path:
+            if not check_exists:
+                return default_file_path
+            elif default_file_path.exists():
+                return default_file_path
 
         return None
 

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -167,6 +167,7 @@ class OSConfiguration:
     shortcut_forbidden_chars: tuple[str, ...] | None = None
     shortcut_icon_extensions: tuple[str, ...] | None = None
     shortcut_icon_default_path: str | None = None
+    qgis_global_settings_file_path: Path | None = None
 
     def _is_envvar_qgis_exe_path_a_dict(self) -> bool:
         """Check if the QDT_QGIS_EXE_PATH environment variable is a dictionary.
@@ -322,6 +323,13 @@ class OSConfiguration:
                 ),
                 shortcut_extension="app",
                 shortcut_icon_extensions=("icns",),
+                qgis_global_settings_file_path=Path(
+                    getenv(
+                        "QGIS_GLOBAL_SETTINGS_FILE",
+                        Path.home()
+                        / "Library/Application Support/QGIS/QGIS3/qgis_global_setting.ini",
+                    )
+                ),
             )
         elif operating_system_codename == "linux":
             return cls(
@@ -337,6 +345,12 @@ class OSConfiguration:
                 shortcut_extension=".desktop",
                 shortcut_icon_extensions=("png", "svg"),
                 shortcut_icon_default_path="qgis",
+                qgis_global_settings_file_path=Path(
+                    getenv(
+                        "QGIS_GLOBAL_SETTINGS_FILE",
+                        Path.home() / ".local/share/QGIS/QGIS3/qgis_global_setting.ini",
+                    )
+                ),
             )
         elif operating_system_codename == "win32":
             return cls(
@@ -354,6 +368,12 @@ class OSConfiguration:
                 shortcut_extension=".lnk",
                 shortcut_forbidden_chars=("<", ">", ":", '"', "/", "\\", "|", "?", "*"),
                 shortcut_icon_extensions=("ico",),
+                qgis_global_settings_file_path=Path(
+                    getenv(
+                        "QGIS_GLOBAL_SETTINGS_FILE",
+                        expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini"),
+                    )
+                ),
             )
         else:
             raise ValueError(

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -268,7 +268,7 @@ class OSConfiguration:
     def get_qgis_global_settings_file_path(
         self, check_exists: bool = True
     ) -> Path | None:
-        """Returns the QGIS global settings file from default value used by QGIS
+        """Returns the QGIS global settings file from default value used by QGIS.
         See https://docs.qgis.org/latest/en/docs/user_manual/introduction/qgis_configuration.html#globalsettingsfile
 
         - first from environment variable QGIS_GLOBAL_SETTINGS_FILE
@@ -276,7 +276,7 @@ class OSConfiguration:
         - then from installation directory
 
         Args:
-            check_exists (bool, optional): _description_. Defaults to True.
+            check_exists (bool, optional): ensure that files exists already. Defaults to True.
 
         Returns:
             Path | None: qgis global settings file path, None if can't define default value

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -265,6 +265,43 @@ class OSConfiguration:
             )
             return Path(expandvars(expanduser(self.qgis_bin_exe_path)))  # noqa: PTH111
 
+    def get_qgis_global_settings_file_path(
+        self, check_exists: bool = True
+    ) -> Path | None:
+        """Returns the QGIS global settings file from default value used by QGIS
+        See https://docs.qgis.org/latest/en/docs/user_manual/introduction/qgis_configuration.html#globalsettingsfile
+
+        - first from environment variable QGIS_GLOBAL_SETTINGS_FILE
+        - second from AppDataLocation folder
+        - then from installation directory
+
+        Args:
+            check_exists (bool, optional): _description_. Defaults to True.
+
+        Returns:
+            Path | None: qgis global settings file path, None if can't define default value
+        """
+
+        # Default value from environment variable and AppDataLocation folder defined in constructor (see from_opersys)
+        default_file_path = self.qgis_global_settings_file_path
+
+        # Check if file exists
+        if default_file_path:
+            if check_exists and default_file_path.exists():
+                return default_file_path
+
+        # Define from qgis bin path
+        qgis_bin_path = self.get_qgis_bin_path()
+        if qgis_bin_path:
+            default_file_path = (
+                Path(qgis_bin_path).parent / "resources" / "qgis_global_settings.ini"
+            )
+
+        if check_exists and default_file_path.exists():
+            return default_file_path
+
+        return None
+
     def valid_shortcut_name(self, shortcut_name: str) -> bool:
         """Check if a given string is a valid shortcut name for the current operating
         system.

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -114,6 +114,10 @@ class JobGlobalConfigManager(GenericJob):
         else:
             dst_path = Path(dst)
 
+        if not dst_path.is_absolute():
+            err_msg = f"dst option file path `{dst_path}` must be absolute for job {self.ID}. Can't update QGIS global settings file."
+            raise ValueError(err_msg)
+
         if dst_path is None:
             err_msg = f"Can't define destination for job {self.ID}."
             raise ValueError(err_msg)

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -14,6 +14,7 @@ Author: Julien Moura (https://github.com/guts)
 import logging
 from os import getenv
 from pathlib import Path
+from posixpath import expanduser, expandvars
 from shutil import copy2
 from sys import platform as opersys
 from urllib.parse import urlsplit
@@ -98,6 +99,9 @@ class JobGlobalConfigManager(GenericJob):
                 err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
                 raise ValueError(err_msg)
 
+        # Interpolate value
+        src = expandvars(expanduser(src))
+
         # Check if src is a url
         if check_str_is_url(input_str=src, raise_error=False):
             logger.info(f"{src} is a valid URL. Downloading QGIS global settings file.")
@@ -126,9 +130,12 @@ class JobGlobalConfigManager(GenericJob):
         # Get destination file
         dst = self.options.get("dst", None)
         if dst is None:
-            dst_path = os_config.get_qgis_global_settings_file_path(check_exists=False)
-        else:
-            dst_path = Path(dst)
+            dst = os_config.get_qgis_global_settings_file_path(check_exists=False)
+
+        # Interpolate value
+        dst = expandvars(expanduser(dst))
+
+        dst_path = Path(dst)
 
         if not dst_path.is_absolute():
             err_msg = f"dst option file path `{dst_path}` must be absolute for job {self.ID}. Can't update QGIS global settings file."

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -21,6 +21,7 @@ from urllib.parse import urlsplit
 # package
 from qgis_deployment_toolbelt.constants import OSConfiguration
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.profiles.qgis_ini_handler import QgisIniHelper
 from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
 from qgis_deployment_toolbelt.utils.slugger import sluggy
 from qgis_deployment_toolbelt.utils.str2bool import str2bool
@@ -141,7 +142,23 @@ class JobGlobalConfigManager(GenericJob):
         try:
             # Create directory for destination
             dst_path.parent.mkdir(parents=True, exist_ok=True)
-            copy2(src=src_path, dst=dst_path)
+
+            # Copy current installed file
+            copy2(
+                src_path,
+                dst_path,
+            )
+
+            dst_ini_helper = QgisIniHelper(
+                ini_filepath=dst_path, ini_type="qgis_global_settings"
+            )
+            src_ini_helper = QgisIniHelper(
+                ini_filepath=src_path, ini_type="qgis_global_settings"
+            )
+
+            # Merge
+            src_ini_helper.merge_to(dst_ini_helper)
+
         except Exception:
             err_msg = f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. Check permission for destination."
             raise ValueError(err_msg)

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -29,7 +29,6 @@ from qgis_deployment_toolbelt.utils.str2bool import str2bool
 from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
 
 
-# 3rd party
 # conditional imports
 if opersys == "win32":
     from qgis_deployment_toolbelt.utils.win32utils import set_environment_variable
@@ -60,16 +59,15 @@ class JobGlobalConfigManager(GenericJob):
     OPTIONS_SCHEMA: dict = {
         "src": {
             "type": str,
-            "required": True,
+            "required": False,
             "possible_values": None,
             "default": None,
         },
         "dst": {
             "type": str,
-            "required": True,
+            "required": False,
             "default": None,
             "possible_values": None,
-            "condition": None,
         },
     }
 
@@ -85,65 +83,12 @@ class JobGlobalConfigManager(GenericJob):
 
     def run(self) -> None:
         """Copy QGIS global settings file to a custom destination and update environment variable for file use in QGIS."""
-        src = self.options.get("src", None)
-
-        os_config: OSConfiguration = OSConfiguration.from_opersys()
 
         # Define source file
-
-        if src is None:
-            # Define default src file from os config
-            src = os_config.get_qgis_global_settings_file_path(check_exists=True)
-
-            if src is None:
-                err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
-                raise ValueError(err_msg)
-
-        # Interpolate value
-        src = expandvars(expanduser(src))
-
-        # Check if src is a url
-        if check_str_is_url(input_str=src, raise_error=False):
-            logger.info(f"{src} is a valid URL. Downloading QGIS global settings file.")
-            try:
-                src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
-            except Exception as exc:
-                err_msg = f"Error download external url `{src}` for job {self.ID} : {exc}. Can't update QGIS global settings file."
-                raise ValueError(err_msg) from exc
-
-        src_path = Path(src)
-
-        # Check if file is relative
-        if not src_path.is_absolute():
-            # Check with downloaded repositories
-            if Path(self.qdt_downloaded_repositories / src_path).exists():
-                src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
-            # Check with QDT working dir
-            elif Path(self.qdt_working_folder / src_path).exists():
-                src_path = Path(self.qdt_working_folder / src_path).resolve()
-
-        # Check file exists
-        if not src_path.exists():
-            err_msg = f"src option file `{src}` is not available for job {self.ID}. Can't update QGIS global settings file."
-            raise ValueError(err_msg)
+        src_path = self.get_src_ini_file(self.options.get("src", None))
 
         # Get destination file
-        dst = self.options.get("dst", None)
-        if dst is None:
-            dst = os_config.get_qgis_global_settings_file_path(check_exists=False)
-
-        # Interpolate value
-        dst = expandvars(expanduser(dst))
-
-        dst_path = Path(dst)
-
-        if not dst_path.is_absolute():
-            err_msg = f"dst option file path `{dst_path}` must be absolute for job {self.ID}. Can't update QGIS global settings file."
-            raise ValueError(err_msg)
-
-        if dst_path is None:
-            err_msg = f"Can't define destination for job {self.ID}."
-            raise ValueError(err_msg)
+        dst_path = self.get_dst_ini_file(self.options.get("dst", None))
 
         # Copy source to destination
         try:
@@ -178,6 +123,92 @@ class JobGlobalConfigManager(GenericJob):
             )
 
         logger.debug(f"Job {self.ID} ran successfully.")
+
+    def get_src_ini_file(self, src: str | None) -> Path:
+        """Get source .ini file from job option
+
+        Args:
+            src (str | None): `src` job option
+
+        Raises:
+            ValueError: Can't define default option for None input
+            ValueError: Can't download .ini file for input url
+            ValueError: `src` option use a file not available
+
+        Returns:
+            Path: path to source .ini file
+        """
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        if src is None:
+            # Define default src file from os config
+            src = os_config.get_qgis_global_settings_file_path(check_exists=True)
+
+            if src is None:
+                err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
+                raise ValueError(err_msg)
+
+        # Interpolate value
+        src = expandvars(expanduser(src))
+
+        # Check if src is a url
+        if check_str_is_url(input_str=src, raise_error=False):
+            logger.info(f"{src} is a valid URL. Downloading QGIS global settings file.")
+            try:
+                src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
+            except Exception as exc:
+                err_msg = f"Error download external url `{src}` for job {self.ID} : {exc}. Can't update QGIS global settings file."
+                raise ValueError(err_msg) from exc
+
+        src_path = Path(src)
+
+        # Check if file is relative
+        if not src_path.is_absolute():
+            # Check with downloaded repositories
+            if Path(self.qdt_downloaded_repositories / src_path).exists():
+                src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
+            # Check with QDT working dir
+            elif Path(self.qdt_working_folder / src_path).exists():
+                src_path = Path(self.qdt_working_folder / src_path).resolve()
+
+        # Check file exists
+        if src_path is None or not src_path.exists():
+            err_msg = f"src option file `{src}` is not available for job {self.ID}. Can't update QGIS global settings file."
+            raise ValueError(err_msg)
+
+        return src_path
+
+    def get_dst_ini_file(self, dst: str | None) -> Path:
+        """Get destination .ini file from job option
+
+        Args:
+            dst (str | None): `dst` job option
+
+        Raises:
+            ValueError: `dst` option use a relative file
+            ValueError: Can't define destination .ini file from default option
+
+        Returns:
+            Path: path to destination .ini file
+        """
+
+        if dst is None:
+            os_config: OSConfiguration = OSConfiguration.from_opersys()
+            dst = os_config.get_qgis_global_settings_file_path(check_exists=False)
+
+        # Interpolate value
+        dst = expandvars(expanduser(dst))
+
+        dst_path = Path(dst)
+
+        if not dst_path.is_absolute():
+            err_msg = f"dst option file path `{dst_path}` must be absolute for job {self.ID}. Can't update QGIS global settings file."
+            raise ValueError(err_msg)
+
+        if dst_path is None:
+            err_msg = f"Can't define destination for job {self.ID}."
+            raise ValueError(err_msg)
+        return dst_path
 
     def get_remote_qgis_global_settings_from_url(self, remote_url: str) -> Path:
         """Download remote qgis global settings and return local file path.

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -12,13 +12,19 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
+from os import getenv
 from pathlib import Path
 from shutil import copy2
 from sys import platform as opersys
+from urllib.parse import urlsplit
 
 # package
 from qgis_deployment_toolbelt.constants import OSConfiguration
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
+from qgis_deployment_toolbelt.utils.slugger import sluggy
+from qgis_deployment_toolbelt.utils.str2bool import str2bool
+from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
 
 
 # 3rd party
@@ -87,9 +93,18 @@ class JobGlobalConfigManager(GenericJob):
             # Define default src file from os config
             src = os_config.get_qgis_global_settings_file_path(check_exists=True)
 
-        if src is None:
-            err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
-            raise ValueError(err_msg)
+            if src is None:
+                err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
+                raise ValueError(err_msg)
+
+        # Check if src is a url
+        if check_str_is_url(input_str=src, raise_error=False):
+            logger.info(f"{src} is a valid URL. Downloading QGIS global settings file.")
+            try:
+                src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
+            except Exception as exc:
+                err_msg = f"Error download external url `{src}` for job {self.ID} : {exc}. Can't update QGIS global settings file."
+                raise ValueError(err_msg) from exc
 
         src_path = Path(src)
 
@@ -139,3 +154,39 @@ class JobGlobalConfigManager(GenericJob):
             )
 
         logger.debug(f"Job {self.ID} ran successfully.")
+
+    def get_remote_qgis_global_settings_from_url(self, remote_url: str) -> Path:
+        """Download remote qgis global settings and return local file path.
+
+        Args:
+            remote_url (str): URL to remote qgis global settings
+
+        Returns:
+            Path: local path to downloaded qgis global settings.
+        """
+        # try to build file path from URL
+        try:
+            url_splitted = urlsplit(remote_url)
+            local_filepath_for_remote_global_settings = (
+                "remote_qgis_global_settings/"
+                f"{sluggy(url_splitted.netloc)}/"
+                f"{sluggy(str(Path(url_splitted.path).parent))}/"
+                f"{Path(url_splitted.path).name}"
+            )
+        except Exception as err:
+            local_filepath_for_remote_global_settings = (
+                "remote_qgis_global_settings/qgis_global_settings.ini"
+            )
+            logger.warning(
+                f"Failed to extract a proper filename from URL: {remote_url}."
+                f" Trace: {err}. Fallback to default: {local_filepath_for_remote_global_settings}"
+            )
+
+        return download_remote_file_to_local(
+            remote_url_to_download=remote_url,
+            local_file_path=Path(
+                self.qdt_working_folder.parent,
+                local_filepath_for_remote_global_settings,
+            ),
+            use_stream=str2bool(getenv("QDT_STREAMED_DOWNLOADS", True)),
+        )

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -1,0 +1,127 @@
+#! python3  # noqa: E265
+
+"""
+Tools to manage the environment setup (variables, etc.)
+
+Author: Julien Moura (https://github.com/guts)
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import logging
+from pathlib import Path
+from shutil import copy2
+from sys import platform as opersys
+
+# package
+from qgis_deployment_toolbelt.constants import OSConfiguration
+from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+
+
+# 3rd party
+# conditional imports
+if opersys == "win32":
+    from qgis_deployment_toolbelt.utils.win32utils import set_environment_variable
+elif opersys == "linux":
+    from qgis_deployment_toolbelt.utils.linux_utils import set_environment_variable
+else:
+    set_environment_variable = None
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+
+# logs
+logger = logging.getLogger(__name__)
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class JobGlobalConfigManager(GenericJob):
+    """
+    Class to manage the global config of QGIS installation.
+    """
+
+    ID: str = "qglobal-config-manager"
+    OPTIONS_SCHEMA: dict = {
+        "src": {
+            "type": str,
+            "required": True,
+            "possible_values": None,
+            "default": None,
+        },
+        "dst": {
+            "type": str,
+            "required": True,
+            "default": None,
+            "possible_values": None,
+            "condition": None,
+        },
+    }
+
+    def __init__(self, options: dict) -> None:
+        """Instantiate the class.
+        Args:
+            options (dict): dictionnary with job options
+            or remove.
+        """
+
+        super().__init__()
+        self.options: dict = self.validate_options(options)
+
+    def run(self) -> None:
+        """Copy QGIS global settings file to a custom destination and update environment variable for file use in QGIS."""
+        src = self.options.get("src", None)
+
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        # Define source file
+
+        if src is None:
+            # Define default src file from os config
+            src = os_config.qgis_global_settings_file_path
+
+        if src is None:
+            err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
+            raise ValueError(err_msg)
+
+        # Check file exists
+        src_path = Path(src)
+        if not src_path.exists():
+            err_msg = f"src option file `{src}` is not available for job {self.ID}. Can't update QGIS global settings file."
+            raise ValueError(err_msg)
+
+        # Get destination file
+        dst = self.options.get("dst", None)
+        if dst is None:
+            dst_path = os_config.qgis_global_settings_file_path
+        else:
+            dst_path = Path(dst)
+
+        if dst_path is None:
+            err_msg = f"Can't define destination for job {self.ID}."
+            raise ValueError(err_msg)
+
+        # Copy source to destination
+        try:
+            # Create directory for destination
+            dst_path.mkdir(parents=True, exist_ok=True)
+            copy2(src=src_path, dst=dst_path)
+        except Exception:
+            err_msg = f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. Check permission for destination."
+            raise ValueError(err_msg)
+
+        # Update environment variable
+        if set_environment_variable is not None:
+            set_environment_variable(
+                envvar_name="QGIS_GLOBAL_SETTINGS_FILE",
+                envvar_value=str(dst_path),
+            )
+
+        logger.debug(f"Job {self.ID} ran successfully.")

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -92,6 +92,8 @@ class JobGlobalConfigManager(GenericJob):
 
         # Copy source to destination
         try:
+            logger.info(f"Copying `{src_path}` to `{dst_path}`")
+
             # Create directory for destination
             dst_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -109,6 +111,9 @@ class JobGlobalConfigManager(GenericJob):
             )
 
             # Merge
+            logger.info(
+                f"Environment variable conversion from `{src_path}` to `{dst_path}`"
+            )
             src_ini_helper.merge_to(dst_ini_helper)
 
         except Exception:
@@ -117,6 +122,9 @@ class JobGlobalConfigManager(GenericJob):
 
         # Update environment variable
         if set_environment_variable is not None:
+            logger.info(
+                f"QGIS_GLOBAL_SETTINGS_FILE environment variable set to `{dst_path}`"
+            )
             set_environment_variable(
                 envvar_name="QGIS_GLOBAL_SETTINGS_FILE",
                 envvar_value=str(dst_path),
@@ -164,12 +172,25 @@ class JobGlobalConfigManager(GenericJob):
 
         # Check if file is relative
         if not src_path.is_absolute():
+            logger.info(f"{src} is a relative path. Conversion to absolute path.")
+
             # Check with downloaded repositories
             if Path(self.qdt_downloaded_repositories / src_path).exists():
                 src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
+                logger.info(
+                    f"{src} relative path converted from downloaded repositories to {src_path}"
+                )
             # Check with QDT working dir
             elif Path(self.qdt_working_folder / src_path).exists():
                 src_path = Path(self.qdt_working_folder / src_path).resolve()
+                logger.info(
+                    f"{src} relative path converted from QDT working folder to {src_path}"
+                )
+            else:
+                src_path = src_path.resolve()
+                logger.warning(
+                    f"{src} relative path converted from current directory : {src_path}"
+                )
 
         # Check file exists
         if src_path is None or not src_path.exists():

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -91,8 +91,18 @@ class JobGlobalConfigManager(GenericJob):
             err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
             raise ValueError(err_msg)
 
-        # Check file exists
         src_path = Path(src)
+
+        # Check if file is relative
+        if not src_path.is_absolute():
+            # Check with downloaded repositories
+            if Path(self.qdt_downloaded_repositories / src_path).exists():
+                src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
+            # Check with QDT working dir
+            elif Path(self.qdt_working_folder / src_path).exists():
+                src_path = Path(self.qdt_working_folder / src_path).resolve()
+
+        # Check file exists
         if not src_path.exists():
             err_msg = f"src option file `{src}` is not available for job {self.ID}. Can't update QGIS global settings file."
             raise ValueError(err_msg)
@@ -111,7 +121,7 @@ class JobGlobalConfigManager(GenericJob):
         # Copy source to destination
         try:
             # Create directory for destination
-            dst_path.mkdir(parents=True, exist_ok=True)
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
             copy2(src=src_path, dst=dst_path)
         except Exception:
             err_msg = f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. Check permission for destination."

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -85,7 +85,7 @@ class JobGlobalConfigManager(GenericJob):
 
         if src is None:
             # Define default src file from os config
-            src = os_config.qgis_global_settings_file_path
+            src = os_config.get_qgis_global_settings_file_path(check_exists=True)
 
         if src is None:
             err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
@@ -100,7 +100,7 @@ class JobGlobalConfigManager(GenericJob):
         # Get destination file
         dst = self.options.get("dst", None)
         if dst is None:
-            dst_path = os_config.qgis_global_settings_file_path
+            dst_path = os_config.get_qgis_global_settings_file_path(check_exists=False)
         else:
             dst_path = Path(dst)
 

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -1,9 +1,6 @@
 #! python3  # noqa: E265
 
-"""
-Job handling QGIS global settings INI file manipulation.
-
-"""
+"""Job handling QGIS global settings INI file manipulation."""
 
 # #############################################################################
 # ########## Libraries #############
@@ -49,7 +46,7 @@ logger = logging.getLogger(__name__)
 # ##################################
 
 
-class JobGlobalConfigManager(GenericJob):
+class JobQgisGlobalConfigManager(GenericJob):
     """
     Class to manage the global config of QGIS installation.
     """
@@ -81,7 +78,8 @@ class JobGlobalConfigManager(GenericJob):
         self.options: dict = self.validate_options(options)
 
     def run(self) -> None:
-        """Copy QGIS global settings file to a custom destination and update environment variable for file use in QGIS."""
+        """Copy QGIS global settings file to a custom destination and update
+        environment variable for file use in QGIS."""
 
         # Define source file
         src_path = self.get_src_ini_file(self.options.get("src", None))
@@ -115,9 +113,12 @@ class JobGlobalConfigManager(GenericJob):
             )
             src_ini_helper.merge_to(dst_ini_helper)
 
-        except Exception:
-            err_msg = f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. Check permission for destination."
-            raise ValueError(err_msg)
+        except Exception as exc:
+            err_msg = (
+                f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. "
+                f"Check permission for destination. Trace: {exc}"
+            )
+            raise ValueError(err_msg) from exc
 
         # Update environment variable
         if set_environment_variable is not None:
@@ -152,7 +153,10 @@ class JobGlobalConfigManager(GenericJob):
             src = os_config.get_qgis_global_settings_file_path(check_exists=True)
 
             if src is None:
-                err_msg = f"Can't define default src option for job {self.ID}. Can't update QGIS global settings file."
+                err_msg = (
+                    f"Can't define default src option for job {self.ID}. "
+                    "Can't update QGIS global settings file."
+                )
                 raise ValueError(err_msg)
 
         # Interpolate value
@@ -164,7 +168,10 @@ class JobGlobalConfigManager(GenericJob):
             try:
                 src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
             except Exception as exc:
-                err_msg = f"Error download external url `{src}` for job {self.ID}: {exc}. Can't update QGIS global settings file."
+                err_msg = (
+                    f"Error download external url `{src}` for job {self.ID}. "
+                    f"Trace: {exc}. Can't update QGIS global settings file."
+                )
                 raise ValueError(err_msg) from exc
 
         src_path = Path(src)
@@ -177,13 +184,15 @@ class JobGlobalConfigManager(GenericJob):
             if Path(self.qdt_downloaded_repositories / src_path).exists():
                 src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
                 logger.info(
-                    f"{src} relative path converted from downloaded repositories to {src_path}"
+                    f"{src} relative path converted from downloaded repositories "
+                    f"to {src_path}"
                 )
             # Check with QDT working dir
             elif Path(self.qdt_working_folder / src_path).exists():
                 src_path = Path(self.qdt_working_folder / src_path).resolve()
                 logger.info(
-                    f"{src} relative path converted from QDT working folder to {src_path}"
+                    f"{src} relative path converted from QDT working folder "
+                    f"to {src_path}"
                 )
             else:
                 src_path = src_path.resolve()
@@ -193,7 +202,10 @@ class JobGlobalConfigManager(GenericJob):
 
         # Check file exists
         if src_path is None or not src_path.exists():
-            err_msg = f"src option file `{src}` is not available for job {self.ID}. Can't update QGIS global settings file."
+            err_msg = (
+                f"src option file `{src}` is not available for job {self.ID}. "
+                "Can't update QGIS global settings file."
+            )
             raise ValueError(err_msg)
 
         return src_path
@@ -205,7 +217,7 @@ class JobGlobalConfigManager(GenericJob):
             dst (str | None): `dst` job option
 
         Raises:
-            ValueError: `dst` option use a relative file
+            ValueError: `dst` option uses a relative file
             ValueError: Can't define destination .ini file from default option
 
         Returns:
@@ -222,7 +234,10 @@ class JobGlobalConfigManager(GenericJob):
         dst_path = Path(dst)
 
         if not dst_path.is_absolute():
-            err_msg = f"dst option file path `{dst_path}` must be absolute for job {self.ID}. Can't update QGIS global settings file."
+            err_msg = (
+                f"dst option file path `{dst_path}` must be absolute "
+                f"for job {self.ID}. Can't update QGIS global settings file."
+            )
             raise ValueError(err_msg)
 
         if dst_path is None:
@@ -253,8 +268,9 @@ class JobGlobalConfigManager(GenericJob):
                 "remote_qgis_global_settings/qgis_global_settings.ini"
             )
             logger.warning(
-                f"Failed to extract a proper filename from URL: {remote_url}."
-                f" Trace: {err}. Fallback to default: {local_filepath_for_remote_global_settings}"
+                f"Failed to extract a proper filename from URL: {remote_url}. "
+                f"Trace: {err}. "
+                f"Fallback to default: {local_filepath_for_remote_global_settings}"
             )
 
         return download_remote_file_to_local(

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -12,13 +12,13 @@ from os import getenv
 from pathlib import Path
 from posixpath import expanduser, expandvars
 from shutil import copy2
-from sys import platform as opersys
 
 # package
 from qgis_deployment_toolbelt.constants import OSConfiguration
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.profiles.qgis_ini_handler import QgisIniHelper
 from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
+from qgis_deployment_toolbelt.utils.os_utils_router import set_environment_variable
 from qgis_deployment_toolbelt.utils.str2bool import str2bool
 from qgis_deployment_toolbelt.utils.url_helpers import (
     check_str_is_url,
@@ -26,18 +26,9 @@ from qgis_deployment_toolbelt.utils.url_helpers import (
 )
 
 
-# conditional imports
-if opersys == "win32":
-    from qgis_deployment_toolbelt.utils.win32utils import set_environment_variable
-elif opersys == "linux":
-    from qgis_deployment_toolbelt.utils.linux_utils import set_environment_variable
-else:
-    set_environment_variable = None
-
 # #############################################################################
 # ########## Globals ###############
 # ##################################
-
 
 # logs
 logger = logging.getLogger(__name__)

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -13,16 +13,17 @@ from pathlib import Path
 from posixpath import expanduser, expandvars
 from shutil import copy2
 from sys import platform as opersys
-from urllib.parse import urlsplit
 
 # package
 from qgis_deployment_toolbelt.constants import OSConfiguration
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.profiles.qgis_ini_handler import QgisIniHelper
 from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
-from qgis_deployment_toolbelt.utils.slugger import sluggy
 from qgis_deployment_toolbelt.utils.str2bool import str2bool
-from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
+from qgis_deployment_toolbelt.utils.url_helpers import (
+    check_str_is_url,
+    filename_from_url,
+)
 
 
 # conditional imports
@@ -256,12 +257,8 @@ class JobQgisGlobalConfigManager(GenericJob):
         """
         # try to build file path from URL
         try:
-            url_splitted = urlsplit(remote_url)
             local_filepath_for_remote_global_settings = (
-                "remote_qgis_global_settings/"
-                f"{sluggy(url_splitted.netloc)}/"
-                f"{sluggy(str(Path(url_splitted.path).parent))}/"
-                f"{Path(url_splitted.path).name}"
+                f"remote_qgis_global_settings/{filename_from_url(remote_url)}"
             )
         except Exception as err:
             local_filepath_for_remote_global_settings = (

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -11,14 +11,11 @@ import logging
 from os import getenv
 from pathlib import Path
 from posixpath import expanduser, expandvars
-from shutil import copy2
 
 # package
 from qgis_deployment_toolbelt.constants import OSConfiguration
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
-from qgis_deployment_toolbelt.profiles.qgis_ini_handler import QgisIniHelper
 from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
-from qgis_deployment_toolbelt.utils.os_utils_router import set_environment_variable
 from qgis_deployment_toolbelt.utils.str2bool import str2bool
 from qgis_deployment_toolbelt.utils.url_helpers import (
     check_str_is_url,
@@ -47,9 +44,10 @@ class JobQgisGlobalConfigManager(GenericJob):
     OPTIONS_SCHEMA: dict = {
         "src": {
             "type": str,
-            "required": False,
+            "required": True,
             "possible_values": None,
-            "default": None,
+            # from QDT working directory or local scenario folder
+            "default": "./global/qgis_global_settings.ini",
         },
         "dst": {
             "type": str,
@@ -62,8 +60,7 @@ class JobQgisGlobalConfigManager(GenericJob):
     def __init__(self, options: dict) -> None:
         """Instantiate the class.
         Args:
-            options (dict): dictionnary with job options
-            or remove.
+            options (dict): dictionnary with job options or remove.
         """
 
         super().__init__()
@@ -76,56 +73,56 @@ class JobQgisGlobalConfigManager(GenericJob):
         # Define source file
         src_path = self.get_src_ini_file(self.options.get("src", None))
 
-        # Get destination file
-        dst_path = self.get_dst_ini_file(self.options.get("dst", None))
+        # # Get destination file
+        # dst_path = self.get_dst_ini_file(self.options.get("dst", None))
 
-        # Copy source to destination
-        try:
-            logger.info(f"Copying `{src_path}` to `{dst_path}`")
+        # # Copy source to destination
+        # try:
+        #     logger.info(f"Copying `{src_path}` to `{dst_path}`")
 
-            # Create directory for destination
-            dst_path.parent.mkdir(parents=True, exist_ok=True)
+        #     # Create directory for destination
+        #     dst_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Copy current installed file
-            copy2(
-                src_path,
-                dst_path,
-            )
+        #     # Copy current installed file
+        #     copy2(
+        #         src_path,
+        #         dst_path,
+        #     )
 
-            dst_ini_helper = QgisIniHelper(
-                ini_filepath=dst_path, ini_type="qgis_global_settings"
-            )
-            src_ini_helper = QgisIniHelper(
-                ini_filepath=src_path, ini_type="qgis_global_settings"
-            )
+        #     dst_ini_helper = QgisIniHelper(
+        #         ini_filepath=dst_path, ini_type="qgis_global_settings"
+        #     )
+        #     src_ini_helper = QgisIniHelper(
+        #         ini_filepath=src_path, ini_type="qgis_global_settings"
+        #     )
 
-            # Merge
-            logger.info(
-                f"Environment variable conversion from `{src_path}` to `{dst_path}`"
-            )
-            src_ini_helper.merge_to(dst_ini_helper)
+        #     # Merge
+        #     logger.info(
+        #         f"Environment variable conversion from `{src_path}` to `{dst_path}`"
+        #     )
+        #     src_ini_helper.merge_to(dst_ini_helper)
 
-        except Exception as exc:
-            err_msg = (
-                f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. "
-                f"Check permission for destination. Trace: {exc}"
-            )
-            raise ValueError(err_msg) from exc
+        # except Exception as exc:
+        #     err_msg = (
+        #         f"Can't copy `{src_path}` to `{dst_path}` for job {self.ID}. "
+        #         f"Check permission for destination. Trace: {exc}"
+        #     )
+        #     raise ValueError(err_msg) from exc
 
-        # Update environment variable
-        if set_environment_variable is not None:
-            logger.info(
-                f"QGIS_GLOBAL_SETTINGS_FILE environment variable set to `{dst_path}`"
-            )
-            set_environment_variable(
-                envvar_name="QGIS_GLOBAL_SETTINGS_FILE",
-                envvar_value=str(dst_path),
-            )
+        # # Update environment variable
+        # if set_environment_variable is not None:
+        #     logger.info(
+        #         f"QGIS_GLOBAL_SETTINGS_FILE environment variable set to `{dst_path}`"
+        #     )
+        #     set_environment_variable(
+        #         envvar_name="QGIS_GLOBAL_SETTINGS_FILE",
+        #         envvar_value=str(dst_path),
+        #     )
 
         logger.debug(f"Job {self.ID} ran successfully.")
 
     def get_src_ini_file(self, src: str | None) -> Path:
-        """Get source .ini file from job option
+        """Get source .ini file from job option.
 
         Args:
             src (str | None): `src` job option
@@ -138,25 +135,17 @@ class JobQgisGlobalConfigManager(GenericJob):
         Returns:
             Path: path to source .ini file
         """
-        os_config: OSConfiguration = OSConfiguration.from_opersys()
-
-        if src is None:
-            # Define default src file from os config
-            src = os_config.get_qgis_global_settings_file_path(check_exists=True)
-
-            if src is None:
-                err_msg = (
-                    f"Can't define default src option for job {self.ID}. "
-                    "Can't update QGIS global settings file."
-                )
-                raise ValueError(err_msg)
+        logger.info(f"Source file passed as parameter (raw): {src}")
 
         # Interpolate value
         src = expandvars(expanduser(src))
+        logger.info(f"Source file (expanded): {src}")
 
         # Check if src is a url
         if check_str_is_url(input_str=src, raise_error=False):
-            logger.info(f"{src} is a valid URL. Downloading QGIS global settings file.")
+            logger.info(
+                f"Remote global config file '{src}' is a valid URL. Downloading QGIS global settings file..."
+            )
             try:
                 src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
             except Exception as exc:
@@ -170,26 +159,47 @@ class JobQgisGlobalConfigManager(GenericJob):
 
         # Check if file is relative
         if not src_path.is_absolute():
-            logger.info(f"{src} is a relative path. Conversion to absolute path.")
+            local_file_match: bool = False
 
-            # Check with downloaded repositories
-            if Path(self.qdt_downloaded_repositories / src_path).exists():
-                src_path = Path(self.qdt_downloaded_repositories / src_path).resolve()
-                logger.info(
-                    f"{src} relative path converted from downloaded repositories "
-                    f"to {src_path}"
-                )
-            # Check with QDT working dir
-            elif Path(self.qdt_working_folder / src_path).exists():
-                src_path = Path(self.qdt_working_folder / src_path).resolve()
-                logger.info(
-                    f"{src} relative path converted from QDT working folder "
-                    f"to {src_path}"
-                )
+            logger.info(
+                f"{src} is a relative path. Starting conversion into absolute path."
+            )
+
+            # Check with downloaded repositories in current scenario
+            logger.info(
+                f"Check if it's relative to the downloaded repository of current scenario: "
+                f"{self.qdt_current_scenario} or then if it's relative to the "
+                f"working directory: {self.qdt_working_folder}"
+            )
+            if Path(self.qdt_current_scenario / src_path).exists():
+                src_path = Path(self.qdt_current_scenario / src_path).resolve()
+                local_file_match = True
+                logger.info(f"Matching repository of current scenario: {src}.")
             else:
+                logger.info(
+                    f"No match with current scenario repository, "
+                    f"{Path(self.qdt_current_scenario / src_path)} does not exits. "
+                    "Checking with QDT working directory."
+                )
+
+            # Check with QDT working dir
+            if (
+                not local_file_match
+                and Path(self.qdt_working_folder / src_path).exists()
+            ):
+                src_path = Path(self.qdt_working_folder / src_path).resolve()
+                logger.info(f"Matching QDT working folder of current scenario: {src}.")
+            else:
+                logger.info(
+                    f"No match with local QDT working folder, "
+                    f"{Path(self.qdt_working_folder / src_path)} does not exits. "
+                    "Fallback to current folder."
+                )
+
+            if not local_file_match:
                 src_path = src_path.resolve()
                 logger.warning(
-                    f"{src} relative path converted from current directory : {src_path}"
+                    f"{src} relative path converted from current directory: {src_path}"
                 )
 
         # Check file exists

--- a/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py
@@ -1,9 +1,8 @@
 #! python3  # noqa: E265
 
 """
-Tools to manage the environment setup (variables, etc.)
+Job handling QGIS global settings INI file manipulation.
 
-Author: Julien Moura (https://github.com/guts)
 """
 
 # #############################################################################
@@ -165,7 +164,7 @@ class JobGlobalConfigManager(GenericJob):
             try:
                 src = self.get_remote_qgis_global_settings_from_url(remote_url=src)
             except Exception as exc:
-                err_msg = f"Error download external url `{src}` for job {self.ID} : {exc}. Can't update QGIS global settings file."
+                err_msg = f"Error download external url `{src}` for job {self.ID}: {exc}. Can't update QGIS global settings file."
                 raise ValueError(err_msg) from exc
 
         src_path = Path(src)

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -34,6 +34,9 @@ from qgis_deployment_toolbelt.jobs.job_profiles_synchronizer import (
 from qgis_deployment_toolbelt.jobs.job_qgis_installation_finder import (
     JobQgisInstallationFinder,
 )
+from qgis_deployment_toolbelt.jobs.job_qglobal_config_manager import (
+    JobGlobalConfigManager,
+)
 from qgis_deployment_toolbelt.jobs.job_shortcuts import JobShortcutsManager
 from qgis_deployment_toolbelt.jobs.job_splash_screen import JobSplashScreenManager
 
@@ -63,6 +66,7 @@ class JobsOrchestrator:
         JobShortcutsManager,
         JobSplashScreenManager,
         JobQgisInstallationFinder,
+        JobGlobalConfigManager,
     )
     PACKAGE_NAME: str = "qgis_deployment_toolbelt.jobs"
 

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -35,7 +35,7 @@ from qgis_deployment_toolbelt.jobs.job_qgis_installation_finder import (
     JobQgisInstallationFinder,
 )
 from qgis_deployment_toolbelt.jobs.job_qglobal_config_manager import (
-    JobGlobalConfigManager,
+    JobQgisGlobalConfigManager,
 )
 from qgis_deployment_toolbelt.jobs.job_shortcuts import JobShortcutsManager
 from qgis_deployment_toolbelt.jobs.job_splash_screen import JobSplashScreenManager
@@ -66,7 +66,7 @@ class JobsOrchestrator:
         JobShortcutsManager,
         JobSplashScreenManager,
         JobQgisInstallationFinder,
-        JobGlobalConfigManager,
+        JobQgisGlobalConfigManager,
     )
     PACKAGE_NAME: str = "qgis_deployment_toolbelt.jobs"
 

--- a/qgis_deployment_toolbelt/profiles/qgis_ini_handler.py
+++ b/qgis_deployment_toolbelt/profiles/qgis_ini_handler.py
@@ -113,6 +113,8 @@ class QgisIniHelper:
             self.profile_config_path = None
             self.profile_customization_path = None
         else:
+            self.profile_config_path = None
+            self.profile_customization_path = None
             logger.warning(f"Unrecognized ini type: {ini_filepath}")
 
         # check if file exists

--- a/qgis_deployment_toolbelt/profiles/qgis_ini_handler.py
+++ b/qgis_deployment_toolbelt/profiles/qgis_ini_handler.py
@@ -42,10 +42,11 @@ logger = logging.getLogger(__name__)
 class QgisIniHelper:
     """Helper to manipulate QGIS configuration files (*.ini)."""
 
-    SUPPORTED_INI_TYPES: tuple[str, str, str] = (
+    SUPPORTED_INI_TYPES: tuple[str, str, str, str] = (
         "plugin_metadata",
         "profile_qgis3",
         "profile_qgis3customization",
+        "qgis_global_settings",
     )
 
     ini_type: str | None = None
@@ -54,7 +55,11 @@ class QgisIniHelper:
         self,
         ini_filepath: Path,
         ini_type: Literal[
-            "profile_qgis3", "profile_qgis3customization", "plugin_metadata", None
+            "profile_qgis3",
+            "profile_qgis3customization",
+            "plugin_metadata",
+            "qgis_global_settings",
+            None,
         ] = None,
         strict: bool = False,
         enable_environment_variables_interpolation: bool = True,
@@ -101,6 +106,10 @@ class QgisIniHelper:
             self.profile_customization_path = ini_filepath
         elif ini_filepath.name == "metadata.txt":
             self.ini_type = "plugin_metadata"
+            self.profile_config_path = None
+            self.profile_customization_path = None
+        elif ini_filepath.name == "qgis_global_settings.ini":
+            self.ini_type = "qgis_global_settings"
             self.profile_config_path = None
             self.profile_customization_path = None
         else:

--- a/tests/fixtures/qgis_ini/qgis_global_settings.ini
+++ b/tests/fixtures/qgis_ini/qgis_global_settings.ini
@@ -1,0 +1,273 @@
+[qgis]
+
+# If true, QGIS will automatically check for new versions on startup and notify users if a new version is available.
+# This setting controls the default value for that setting. Users may still manually enable or disable this check
+# through the QGIS settings dialog.
+checkVersion=true
+
+# If true, users may control whether the version check is enabled or disabled through the QGIS settings dialog. (The default
+# check behavior is determined by the 'checkVersion' setting). If false, no version checking will be performed and
+# users will NOT have an option to enable this check in the settings dialog.
+# This setting is intended for use in enterprise installs where QGIS version management is handled centrally.
+allowVersionCheck=true
+
+# If true, added layer names will be automatically capitalized and underscores replaced with spaces
+formatLayerName=false
+
+# If set to true then directories will be automatically monitored and refreshed when their contents change outside of QGIS.
+# This monitoring can be expensive, especially for remote or network drives, in which case setting this option to false
+# can result in a speedup of the QGIS interface.
+monitorDirectoriesInBrowser=true
+
+[digitizing]
+
+# Snapping enabled by default
+default-snap-enabled=false
+
+# Default snapping tolerance (distance)
+default-snapping-tolerance=12.0
+
+# Default snap to type
+# Vertex, VertexAndSegment, Segment
+default-snap-type=Vertex
+
+# Default snapping unit
+# LayerUnits, Pixels, ProjectUnits
+default-snapping-tolerance-unit=Pixels
+
+# Snap on invisible feature
+snap-invisible-feature=false
+
+[connections]
+
+# Default XYZ tile servers to include
+xyz\items\OpenStreetMap\authcfg=
+xyz\items\OpenStreetMap\password=
+xyz\items\OpenStreetMap\referer=
+xyz\items\OpenStreetMap\url=https://tile.openstreetmap.org/{z}/{x}/{y}.png?{usage}
+xyz\items\OpenStreetMap\username=
+xyz\items\OpenStreetMap\zmax=19
+xyz\items\OpenStreetMap\zmin=0
+xyz\items\OpenStreetMap\tile-pixel-ratio=1
+
+xyz\items\Mapzen Global Terrain\authcfg=
+xyz\items\Mapzen Global Terrain\password=
+xyz\items\Mapzen Global Terrain\referer=
+xyz\items\Mapzen Global Terrain\url=https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png?{usage}
+xyz\items\Mapzen Global Terrain\username=
+xyz\items\Mapzen Global Terrain\zmax=15
+xyz\items\Mapzen Global Terrain\zmin=0
+xyz\items\Mapzen Global Terrain\interpretation=terrariumterrain
+
+[qgis]
+
+# The image format selected by default when adding a WMS, i.e. image/png. If empty, the first available format is used
+WMSDefaultFormat=""
+
+# application stylesheet
+
+# Padding (in pixels) to add to toolbar icons, if blank then default padding will be used
+stylesheet\toolbarSpacing=
+
+# If true, new projects are using relative paths. If false, new projects default to absolute paths.
+defaultProjectPathsRelative=true
+
+# Max image cache size in bytes.
+# The cache is used for caching symbology and layout images,
+# If high resolution images are used for printing layout, then this
+# value should be increased accordingly.
+# If 0, will use a default value calculated based on the system memory (which defaults to 100mb)
+maxImageCacheSize=0
+
+[app]
+
+# Whether the user should be asked to save a layer in case of one or more MemoryLayers
+# when a project is closed.
+# Default to true, set to false to disable this dialog/question.
+askToSaveMemoryLayers=true
+
+# Maximum number of recent projects to show on the welcome page
+maxRecentProjects=20
+
+# Minimum time (in seconds) for a background task to execute in order for a system
+# notification to be shown when the task completes.
+minTaskLengthForSystemNotification=5
+
+# Whether to show the distance panned message in the status bar after a map pan operation
+# occurs. Set to false to disable the message.
+showPanDistanceInStatusBar=true
+
+# Whether to prompt users for a selection when multiple possible transformation paths exist
+# when transforming coordinates. If false, a reasonable choice will be estimated by default
+# without asking users. If true, users are always required to make this choice themselves.
+projections\promptWhenMultipleTransformsExist=true
+
+# Default CRS for newly created projects. Accepts "auth:code" style strings (e.g. EPSG:4326),
+# PROJ strings (must be prefixed with PROJ4:, e.g. "PROJ4:+proj ...."), or WKT strings (must
+# be prefixed with WKT:, e.g. "WKT:<wkt string>")
+# This is only used when projections\newProjectCrsBehavior is set to UsePresetCrs
+projections\defaultProjectCrs=EPSG:4326
+
+# Specifies the method to set the CRS for a newly created project. Valid options are
+# "UseCrsOfFirstLayerAdded" - sets the project CRS to match the CRS of the first layer added to the project
+# "UsePresetCrs" - always use a preset CRS, see projections\defaultProjectCrs
+projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
+
+# Specifies the behavior when adding a layer with unknown/invalid CRS to a project
+# "NoAction" - take no action and leave as unknown CRS
+# "PromptUserForCrs" - user is prompted for a CRS choice
+# "UseProjectCrs" - copy the current project's CRS
+# "UseDefaultCrs" - use the default layer CRS set via QGIS options
+projections\unknownCrsBehavior=NoAction
+
+# If the inherent inaccuracy in a selected CRS exceeds this threshold value (in meters),
+# a warning message will be shown to the user advising them to select an alternative
+# CRS if higher positional accuracy is required
+projections\crsAccuracyWarningThreshold=0.0
+
+# If set to true, a warning icon will be shown next to any layer where the layer's CRS exceeds
+# the accuracy warning threshold value (see crsAccuracyWarningThreshold)
+projections\crsAccuracyIndicator=false
+
+[app]
+
+# Specifies a manual bearing correction to apply to bearings reported by a GPS
+# device, for use when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\bearingAdjustment=0
+
+# Set to "true" to automatically correct GPS reported bearings for true north
+# when a map canvas is set to match rotation to the GPS bearing
+# or when showing the GPS bearing line
+gps\correctForTrueNorth=false
+
+
+[gps]
+
+# Desired flow control mode for serial port GPS connections
+# "NoFlowControl" - no flow control
+# "HardwareControl" - hardware flow control (RTS/CTS)
+# "SoftwareControl" - software flow control (XON/XOFF)
+flow-control=NoFlowControl
+
+# Desired parity checking mode for serial port GPS connections
+# "NoParity" - No parity bit it sent. This is the most common parity setting. Error detection is handled by the communication protocol.
+# "EvenParity" - The number of 1 bits in each character, including the parity bit, is always even.
+# "OddParity" - The number of 1 bits in each character, including the parity bit, is always odd. It ensures that at least one state transition occurs in each character.
+# "SpaceParity" - Space parity. The parity bit is sent in the space signal condition. It does not provide error detection information.
+# "MarkParity" - Mark parity. The parity bit is always set to the mark signal condition (logical 1). It does not provide error detection information.
+parity=NoParity
+
+# Desired data bits in a frame for serial port GPS connections
+# "Data5" - The number of data bits in each character is 5. It is used for Baudot code. It generally only makes sense with older equipment such as teleprinters.
+# "Data6" - The number of data bits in each character is 6. It is rarely used.
+# "Data7" - The number of data bits in each character is 7. It is used for true ASCII. It generally only makes sense with older equipment such as teleprinters.
+# "Data8" - The number of data bits in each character is 8. It is used for most kinds of data, as this size matches the size of a byte. It is almost universally used in newer applications.
+data-bits=Data8
+
+# Desired number of stop bits in a frame for serial port GPS connections
+# "OneStop" - 1 stop bit.
+# "OneAndHalfStop" - 1.5 stop bits. This is only for the Windows platform.
+# "TwoStop" - 2 stop bits.
+stop-bits=OneStop
+
+# Default for GPS leap seconds correction as of 2019-06-19
+leapSecondsCorrection=18
+
+[core]
+
+# Whether or not to anonymize newly created projects
+# If set to true, then project metadata items like AUTHOR and CREATION DATE
+# will not be automatically populated when a new project is created.
+projects\anonymize_new_projects=false
+
+# Whether or not to anonymize projects when saving
+# If set to true, then username information will not be stored in saved projects
+projects\anonymize_saved_projects=false
+
+# News feed settings
+# Set to true to disable the QGIS news feed on the welcome page
+NewsFeed\http00008000\disabled=false
+
+# Optionally, set to an ISO-939-1 two letter language code to filter the QGIS news feed by language
+NewsFeed\http00008000\lang=
+
+# Optionally, set to a specific user latitude and longitude to filter the QGIS news feed to remove
+# local news outside of the users geographic area
+NewsFeed\http00008000\lat=
+NewsFeed\http00008000\long=
+
+# When new projects are created, default to planimetric measurement.
+measure\planimetric=false
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for point features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_points=0
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for line features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_lines=0
+
+# When set to a non-zero value, places a global limit on the maximum number of label candidates which
+# are generated for polygon features. Setting this limit to a low (non-zero) value can improve map rendering
+# time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
+# that no limit is present.
+rendering\label_candidates_limit_polygons=0
+
+[colors]
+# These colors are used in logs.
+default=
+info=
+success=
+warning=#dc7d00
+critical=#c80000
+
+[help]
+# Default help location to include
+# for now this is online version of the User Guide for latest (LTR) release
+helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_manual/
+
+[providers]
+# Whether deprecated data providers should be shown in the QGIS UI (e.g. db2)
+# Warning: these providers are NOT supported and they will be dropped in a future QGIS
+# version. Commercial users requiring on these providers should contact the QGIS
+# project ASAP and arrange for ongoing funding of the provider to prevent their
+# removal and restore them to fully supported status.
+showDeprecated=false
+
+# Default timeout for PostgreSQL servers (seconds)
+PostgreSQL\default_timeout=30
+
+[gui]
+# Maximum number of entries to show in Relation Reference widgets. Too large a number here can
+# cause performance issues, as the records must all be loaded from the related table on display.
+maxEntriesRelationWidget=100
+
+# Path to default image to use for layout north arrows
+# Acceptable formats include local paths, http(s) urls, or even base64 encoded SVGs (prefixed with base64:....)
+LayoutDesigner\defaultNorthArrow=:/images/north_arrows/layout_default_north_arrow.svg
+
+# Default font to use in layout designer
+LayoutDesigner\defaultFont=
+
+[geometry_validation]
+# A comma separated list of geometry validations to enable by default for newly added layers
+# Available checks: QgsIsValidCheck,QgsGeometryGapCheck,QgsGeometryOverlapCheck,QgsGeometryMissingVertexCheck
+default_checks=
+
+# Enable problem resolution for geometry errors
+# This feature is experimental and has known issues.
+enable_problem_resolution=false
+
+
+# Path to (or command name for) the GPSBabel executable file
+gpsbabelPath=gpsbabel
+
+[proxy]
+# # URL list for which proxy configuration doesn't apply. In the case of these URLs, the default system proxy configuration
+# # is applied
+# proxyExcludedUrls=http://intranet,http://anotherproxy

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -50,6 +50,7 @@ class TestConstants(unittest.TestCase):
         self.assertIsInstance(os_config.shortcut_extension, str)
         self.assertIsInstance(os_config.shortcut_forbidden_chars, (tuple, type(None)))
         self.assertIsInstance(os_config.shortcut_icon_extensions, tuple)
+        self.assertIsInstance(os_config.qgis_global_settings_file_path, Path)
 
         # Check for forbidden characters in the shortcut name
         os_config_forbidden_chars = OSConfiguration(
@@ -177,6 +178,54 @@ class TestConstants(unittest.TestCase):
 
         environ.pop("QGIS_CUSTOM_CONFIG_PATH")
         unsetenv("QGIS_CUSTOM_CONFIG_PATH")
+
+    def test_get_qgis_global_settings_file(self):
+        """Test QGIS global settings file."""
+
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        self.assertTrue(is_dataclass(os_config))
+        self.assertIsInstance(os_config, OSConfiguration)
+
+        if opersys == "linux":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                Path.home() / ".local/share/QGIS/QGIS3/qgis_global_setting.ini",
+            )
+        elif opersys == "darwin":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                Path.home()
+                / "Library/Application Support/QGIS/QGIS3/qgis_global_setting.ini",
+            )
+        elif opersys == "win32":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini"),
+            )
+
+    def test_get_qgis_global_settings_file_custom(self):
+        """Test QGIS global settings file custom."""
+        if "QGIS_GLOBAL_SETTINGS_FILE" in environ:
+            environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+
+        custom_qgis_global_settings_file = Path(
+            "tests/fixtures/tmp/custom_qgis_global_settings_file"
+        )
+        environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{custom_qgis_global_settings_file}"
+
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        self.assertTrue(is_dataclass(os_config))
+        self.assertIsInstance(os_config, OSConfiguration)
+
+        self.assertEqual(
+            os_config.qgis_global_settings_file_path,
+            custom_qgis_global_settings_file,
+        )
+
+        environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+        unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
 
 
 # ############################################################################

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -189,18 +189,18 @@ class TestConstants(unittest.TestCase):
 
         if opersys == "linux":
             self.assertEqual(
-                os_config.qgis_global_settings_file_path,
+                os_config.get_qgis_global_settings_file_path(check_exists=False),
                 Path.home() / ".local/share/QGIS/QGIS3/qgis_global_setting.ini",
             )
         elif opersys == "darwin":
             self.assertEqual(
-                os_config.qgis_global_settings_file_path,
+                os_config.get_qgis_global_settings_file_path(check_exists=False),
                 Path.home()
                 / "Library/Application Support/QGIS/QGIS3/qgis_global_setting.ini",
             )
         elif opersys == "win32":
             self.assertEqual(
-                os_config.qgis_global_settings_file_path,
+                os_config.get_qgis_global_settings_file_path(check_exists=False),
                 expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini"),
             )
 
@@ -220,7 +220,7 @@ class TestConstants(unittest.TestCase):
         self.assertIsInstance(os_config, OSConfiguration)
 
         self.assertEqual(
-            os_config.qgis_global_settings_file_path,
+            os_config.get_qgis_global_settings_file_path(check_exists=False),
             custom_qgis_global_settings_file,
         )
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -227,6 +227,91 @@ class TestConstants(unittest.TestCase):
         environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
         unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
 
+    def test_qgis_global_settings_file_exists(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_constants_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            custom_qgis_global_settings_file = (
+                Path(tmpdirname) / "custom_qgis_global_settings_file.ini"
+            )
+            environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{custom_qgis_global_settings_file}"
+            custom_qgis_global_settings_file.write_text("[qgis]\ncheckVersion=true")
+
+            os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+            self.assertTrue(is_dataclass(os_config))
+            self.assertIsInstance(os_config, OSConfiguration)
+
+            self.assertEqual(
+                os_config.get_qgis_global_settings_file_path(check_exists=True),
+                custom_qgis_global_settings_file,
+            )
+
+            environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+            unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
+
+    def test_custom_qgis_global_settings_file_dont_exists(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_constants_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            temp_qgis_exe_path = Path(tmpdirname) / "bin"
+            environ["QDT_QGIS_EXE_PATH"] = f"{temp_qgis_exe_path}"
+
+            default_qgis_global_setting_path = (
+                Path(tmpdirname) / "resources" / "qgis_global_settings.ini"
+            )
+            default_qgis_global_setting_path.parent.mkdir()
+            default_qgis_global_setting_path.write_text("[qgis]\ncheckVersion=true")
+
+            custom_qgis_global_settings_file = (
+                Path(tmpdirname) / "custom_qgis_global_settings_file.ini"
+            )
+            environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{custom_qgis_global_settings_file}"
+
+            os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+            self.assertTrue(is_dataclass(os_config))
+            self.assertIsInstance(os_config, OSConfiguration)
+
+            self.assertEqual(
+                os_config.get_qgis_global_settings_file_path(check_exists=True),
+                default_qgis_global_setting_path,
+            )
+
+            environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+            unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
+
+            environ.pop("QDT_QGIS_EXE_PATH")
+            unsetenv("QDT_QGIS_EXE_PATH")
+
+    def test_qgis_global_settings_file_dont_exists(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_constants_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            temp_qgis_exe_path = Path(tmpdirname) / "bin" / "qgis"
+            environ["QDT_QGIS_EXE_PATH"] = f"{temp_qgis_exe_path}"
+
+            custom_qgis_global_settings_file = (
+                Path(tmpdirname) / "custom_qgis_global_settings_file.ini"
+            )
+            environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{custom_qgis_global_settings_file}"
+
+            os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+            self.assertTrue(is_dataclass(os_config))
+            self.assertIsInstance(os_config, OSConfiguration)
+
+            self.assertEqual(
+                os_config.get_qgis_global_settings_file_path(check_exists=True),
+                None,
+            )
+
+            environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+            unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
+
+            environ.pop("QDT_QGIS_EXE_PATH")
+            unsetenv("QDT_QGIS_EXE_PATH")
+
 
 # ############################################################################
 # ####### Stand-alone run ########

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -201,7 +201,7 @@ class TestConstants(unittest.TestCase):
         elif opersys == "win32":
             self.assertEqual(
                 os_config.get_qgis_global_settings_file_path(check_exists=False),
-                expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini"),
+                Path(expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini")),
             )
 
     def test_get_qgis_global_settings_file_custom(self):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -312,6 +312,54 @@ class TestConstants(unittest.TestCase):
             environ.pop("QDT_QGIS_EXE_PATH")
             unsetenv("QDT_QGIS_EXE_PATH")
 
+    def test_get_qgis_global_settings_file(self):
+        """Test QGIS global settings file."""
+
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        self.assertTrue(is_dataclass(os_config))
+        self.assertIsInstance(os_config, OSConfiguration)
+
+        if opersys == "linux":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                Path.home() / ".local/share/QGIS/QGIS3/qgis_global_setting.ini",
+            )
+        elif opersys == "darwin":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                Path.home()
+                / "Library/Application Support/QGIS/QGIS3/qgis_global_setting.ini",
+            )
+        elif opersys == "win32":
+            self.assertEqual(
+                os_config.qgis_global_settings_file_path,
+                expandvars("%APPDATA%/QGIS/QGIS3/qgis_global_setting.ini"),
+            )
+
+    def test_get_qgis_global_settings_file_custom(self):
+        """Test QGIS global settings file custom."""
+        if "QGIS_GLOBAL_SETTINGS_FILE" in environ:
+            environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+
+        custom_qgis_global_settings_file = Path(
+            "tests/fixtures/tmp/custom_qgis_global_settings_file"
+        )
+        environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{custom_qgis_global_settings_file}"
+
+        os_config: OSConfiguration = OSConfiguration.from_opersys()
+
+        self.assertTrue(is_dataclass(os_config))
+        self.assertIsInstance(os_config, OSConfiguration)
+
+        self.assertEqual(
+            os_config.qgis_global_settings_file_path,
+            custom_qgis_global_settings_file,
+        )
+
+        environ.pop("QGIS_GLOBAL_SETTINGS_FILE")
+        unsetenv("QGIS_GLOBAL_SETTINGS_FILE")
+
 
 # ############################################################################
 # ####### Stand-alone run ########

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -227,3 +227,46 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 job.run()
+
+    def test_url_src(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": "https://raw.githubusercontent.com/qgis/QGIS/refs/heads/master/resources/qgis_global_settings.ini",
+                    "dst": str(dst_file),
+                }
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+
+    def test_invalid_src_url(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": "https://invalidrepository.com/qgis/QGIS/refs/heads/master/resources/qgis_global_settings.ini",
+                    "dst": "../qgis_global_settings.ini",
+                }
+            )
+
+            with self.assertRaises(ValueError):
+                job.run()

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -1,0 +1,104 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+.. code-block:: python
+
+    # for whole test
+    python -m unittest tests.test_job_environment_variables
+    # for specific
+    python -m unittest tests.test_job_environment_variables
+        .TestJobEnvironmentVariables.test_environment_variables_set
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+# Standard library
+import tempfile
+import unittest
+from pathlib import Path
+from sys import platform as opersys
+
+# package
+from qgis_deployment_toolbelt.jobs.job_qglobal_config_manager import (
+    JobGlobalConfigManager,
+)
+
+
+# 3rd party
+# conditional imports
+if opersys == "win32":
+    from qgis_deployment_toolbelt.utils.win32utils import get_environment_variable
+elif opersys == "linux":
+    from qgis_deployment_toolbelt.utils.linux_utils import get_environment_variable
+else:
+    get_environment_variable = None
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class TestJobGlobalConfigManager(unittest.TestCase):
+    """Test module."""
+
+    # -- Standard methods --------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """Executed when module is loaded before any test."""
+
+    # standard methods
+    def setUp(self):
+        """Fixtures prepared before each test."""
+        pass
+
+    def tearDown(self):
+        """Executed after each test."""
+        pass
+
+    # -- TESTS ---------------------------------------------------------
+
+    def test_job_id(self):
+        """Test JobGlobalConfigManager id"""
+        job = JobGlobalConfigManager({})
+        self.assertEqual(job.ID, "qglobal-config-manager")
+
+    def test_invalid_src(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            unexisting_config_file = Path(tmpdirname).joinpath("non_existing.ini")
+            self.assertFalse(unexisting_config_file.exists())
+
+            job = JobGlobalConfigManager({"src": str(unexisting_config_file)})
+
+            with self.assertRaises(ValueError):
+                job.run()
+
+    def test_valid(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {"src": str(config_file), "dst": str(dst_file)}
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 from os import environ
 from pathlib import Path
+from posixpath import expanduser, expandvars
 from sys import platform as opersys
 
 # package
@@ -103,6 +104,41 @@ class TestJobGlobalConfigManager(unittest.TestCase):
                     get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
                     str(dst_file),
                 )
+
+    def test_valid_with_env_var(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text(
+                "[help]\nhelpSearchPath=$HOME/offline_qgis_doc", encoding="UTF-8"
+            )
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {"src": str(config_file), "dst": str(dst_file)}
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+            read_ini = dst_file.read_text("UTF-8")
+            self.assertEqual(
+                read_ini,
+                expanduser(
+                    expandvars("[help]\nhelpSearchPath = $HOME/offline_qgis_doc\n\n")
+                ),
+            )
 
     def test_relative_source_qdt_work_dir(self):
         with tempfile.TemporaryDirectory(

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -270,3 +270,70 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 job.run()
+
+    def test_default_src(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            temp_qgis_exe_path = Path(tmpdirname) / "bin"
+            environ["QDT_QGIS_EXE_PATH"] = f"{temp_qgis_exe_path}"
+
+            default_qgis_global_setting_path = (
+                Path(tmpdirname) / "resources" / "qgis_global_settings.ini"
+            )
+            default_qgis_global_setting_path.parent.mkdir()
+            default_qgis_global_setting_path.write_text("[qgis]\ncheckVersion=true")
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {
+                    "dst": str(dst_file),
+                }
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+
+        # clean up environment vars
+        environ.pop("QDT_QGIS_EXE_PATH")
+
+    def test_default_dst(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            default_dst = (
+                Path(tmpdirname).joinpath("qgis_global_settings.ini").resolve()
+            )
+            environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{default_dst}"
+
+            job = JobGlobalConfigManager({"src": str(config_file)})
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(default_dst.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(default_dst),
+                )
+
+        # clean up environment vars
+        environ.pop("QGIS_GLOBAL_SETTINGS_FILE")

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -17,6 +17,7 @@
 # Standard library
 import tempfile
 import unittest
+from os import environ
 from pathlib import Path
 from sys import platform as opersys
 
@@ -102,3 +103,91 @@ class TestJobGlobalConfigManager(unittest.TestCase):
                     get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
                     str(dst_file),
                 )
+
+    def test_relative_source_qdt_work_dir(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            qdt_local_workdir = (
+                Path(tmpdirname).joinpath("qdt_working_folder").resolve()
+            )
+            environ["QDT_LOCAL_WORK_DIR"] = f"{qdt_local_workdir}"
+            qdt_local_workdir.mkdir(parents=True)
+
+            # Config file related to QDT_LOCAL_WORK_DIR
+            config_file = qdt_local_workdir.joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": "./custom_qgis_global_settings.ini",
+                    "dst": str(dst_file),
+                }
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+
+        # clean up environment vars
+        environ.pop("QDT_LOCAL_WORK_DIR")
+
+    def test_relative_source_qdt_repository(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            qdt_local_workdir = (
+                Path(tmpdirname).joinpath("qdt_working_folder").resolve()
+            )
+            environ["QDT_LOCAL_WORK_DIR"] = f"{qdt_local_workdir}"
+            qdt_local_workdir.mkdir(parents=True)
+
+            qdt_downloaded_repositories = qdt_local_workdir / "repositories" / "default"
+            qdt_downloaded_repositories.mkdir(parents=True)
+
+            qdt_downloaded_repository = qdt_downloaded_repositories.joinpath(
+                "myprofiles"
+            )
+            qdt_downloaded_repository.mkdir(parents=True)
+
+            # Config file related to downloaded repositories
+            config_file = qdt_downloaded_repository.joinpath(
+                "custom_qgis_global_settings.ini"
+            )
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": "./myprofiles/custom_qgis_global_settings.ini",
+                    "dst": str(dst_file),
+                }
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+
+        # clean up environment vars
+        environ.pop("QDT_LOCAL_WORK_DIR")

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -151,6 +151,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
                 Path(tmpdirname).joinpath("qdt_working_folder").resolve()
             )
             environ["QDT_LOCAL_WORK_DIR"] = f"{qdt_local_workdir}"
+            environ["QDT_TMP_RUNNING_SCENARIO_ID"] = "default"
             qdt_local_workdir.mkdir(parents=True)
 
             qdt_downloaded_repositories = qdt_local_workdir / "repositories" / "default"
@@ -191,6 +192,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
         # clean up environment vars
         environ.pop("QDT_LOCAL_WORK_DIR")
+        environ.pop("QDT_TMP_RUNNING_SCENARIO_ID")
 
     def test_dst_copy_exception(self):
         with tempfile.TemporaryDirectory(
@@ -202,7 +204,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             job = JobGlobalConfigManager(
                 {
                     "src": str(config_file),
-                    "dst": "/usr/share/qgis/resources/qgis_global_settings.ini",
+                    "dst": "/sys/dev/qgis_global_settings.ini",
                 }
             )
 

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -191,3 +191,37 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
         # clean up environment vars
         environ.pop("QDT_LOCAL_WORK_DIR")
+
+    def test_dst_copy_exception(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": str(config_file),
+                    "dst": "/usr/share/qgis/resources/qgis_global_settings.ini",
+                }
+            )
+
+            with self.assertRaises(ValueError):
+                job.run()
+
+    def test_relative_dst(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
+            config_file.write_text("[qgis]\ncheckVersion=true")
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": str(config_file),
+                    "dst": "../qgis_global_settings.ini",
+                }
+            )
+
+            with self.assertRaises(ValueError):
+                job.run()

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -140,6 +140,39 @@ class TestJobGlobalConfigManager(unittest.TestCase):
                 ),
             )
 
+    def test_valid_with_env_var_options(self):
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            environ["CUSTOM_GLOBAL_SETTINGS"] = f"{Path(tmpdirname)}"
+
+            config_file = Path(tmpdirname).joinpath("input_qgis_global_settings.ini")
+            config_file.write_text(
+                "[help]\nhelpSearchPath=$HOME/offline_qgis_doc", encoding="UTF-8"
+            )
+
+            dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
+
+            job = JobGlobalConfigManager(
+                {
+                    "src": "$CUSTOM_GLOBAL_SETTINGS/input_qgis_global_settings.ini",
+                    "dst": "$CUSTOM_GLOBAL_SETTINGS/dest/custom_qgis_global_settings.ini",
+                }
+            )
+
+            # Run job
+            job.run()
+
+            # Check file exists
+            self.assertTrue(dst_file.exists())
+
+            # Check environment variable QGIS_GLOBAL_SETTINGS_FILE is updated
+            if get_environment_variable is not None:
+                self.assertEqual(
+                    get_environment_variable("QGIS_GLOBAL_SETTINGS_FILE"),
+                    str(dst_file),
+                )
+
     def test_relative_source_qdt_work_dir(self):
         with tempfile.TemporaryDirectory(
             prefix="qdt_test_ini_file_", ignore_cleanup_errors=True

--- a/tests/test_job_qglobal_config_manager.py
+++ b/tests/test_job_qglobal_config_manager.py
@@ -24,7 +24,7 @@ from sys import platform as opersys
 
 # package
 from qgis_deployment_toolbelt.jobs.job_qglobal_config_manager import (
-    JobGlobalConfigManager,
+    JobQgisGlobalConfigManager,
 )
 
 
@@ -64,7 +64,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
     def test_job_id(self):
         """Test JobGlobalConfigManager id"""
-        job = JobGlobalConfigManager({})
+        job = JobQgisGlobalConfigManager({})
         self.assertEqual(job.ID, "qglobal-config-manager")
 
     def test_invalid_src(self):
@@ -74,7 +74,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             unexisting_config_file = Path(tmpdirname).joinpath("non_existing.ini")
             self.assertFalse(unexisting_config_file.exists())
 
-            job = JobGlobalConfigManager({"src": str(unexisting_config_file)})
+            job = JobQgisGlobalConfigManager({"src": str(unexisting_config_file)})
 
             with self.assertRaises(ValueError):
                 job.run()
@@ -88,7 +88,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {"src": str(config_file), "dst": str(dst_file)}
             )
 
@@ -116,7 +116,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {"src": str(config_file), "dst": str(dst_file)}
             )
 
@@ -153,7 +153,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": "$CUSTOM_GLOBAL_SETTINGS/input_qgis_global_settings.ini",
                     "dst": "$CUSTOM_GLOBAL_SETTINGS/dest/custom_qgis_global_settings.ini",
@@ -189,7 +189,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": "./custom_qgis_global_settings.ini",
                     "dst": str(dst_file),
@@ -239,7 +239,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": "./myprofiles/custom_qgis_global_settings.ini",
                     "dst": str(dst_file),
@@ -270,7 +270,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
             config_file.write_text("[qgis]\ncheckVersion=true")
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": str(config_file),
                     "dst": "/sys/dev/qgis_global_settings.ini",
@@ -287,7 +287,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
             config_file.write_text("[qgis]\ncheckVersion=true")
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": str(config_file),
                     "dst": "../qgis_global_settings.ini",
@@ -303,7 +303,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
         ) as tmpdirname:
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": "https://raw.githubusercontent.com/qgis/QGIS/refs/heads/master/resources/qgis_global_settings.ini",
                     "dst": str(dst_file),
@@ -330,7 +330,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             config_file = Path(tmpdirname).joinpath("custom_qgis_global_settings.ini")
             config_file.write_text("[qgis]\ncheckVersion=true")
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "src": "https://invalidrepository.com/qgis/QGIS/refs/heads/master/resources/qgis_global_settings.ini",
                     "dst": "../qgis_global_settings.ini",
@@ -355,7 +355,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
 
             dst_file = Path(tmpdirname) / "dest" / "custom_qgis_global_settings.ini"
 
-            job = JobGlobalConfigManager(
+            job = JobQgisGlobalConfigManager(
                 {
                     "dst": str(dst_file),
                 }
@@ -389,7 +389,7 @@ class TestJobGlobalConfigManager(unittest.TestCase):
             )
             environ["QGIS_GLOBAL_SETTINGS_FILE"] = f"{default_dst}"
 
-            job = JobGlobalConfigManager({"src": str(config_file)})
+            job = JobQgisGlobalConfigManager({"src": str(config_file)})
 
             # Run job
             job.run()

--- a/tests/test_qgis_ini_helper.py
+++ b/tests/test_qgis_ini_helper.py
@@ -269,6 +269,38 @@ class TestQgisIniHelper(unittest.TestCase):
             self.assertIn("Section", cfg_parser)
             self.assertEqual("new_value", cfg_parser["Section"]["value"])
 
+    def test_load_qgis_global_settings(self):
+        """Test qgis_global_settings.ini loader."""
+        new_config_file = Path("tests/fixtures/qgis_ini/qgis_global_settings.ini")
+
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            tmp_copy = Path(tmpdirname).joinpath(new_config_file.name)
+            tmp_copy.write_text(new_config_file.read_text())
+
+            # open temp copy
+            ini_config = QgisIniHelper(ini_filepath=tmp_copy)
+
+        self.assertEqual(ini_config.ini_type, "qgis_global_settings")
+        self.assertIsNone(ini_config.is_ui_customization_enabled())
+
+    def test_load_non_qgis_settings(self):
+        """Test non qgis .ini loader."""
+        new_config_file = Path("tests/fixtures/qgis_ini/test_ini_interpolated.ini")
+
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_ini_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            tmp_copy = Path(tmpdirname).joinpath(new_config_file.name)
+            tmp_copy.write_text(new_config_file.read_text())
+
+            # open temp copy
+            ini_config = QgisIniHelper(ini_filepath=tmp_copy)
+
+        self.assertIsNone(ini_config.ini_type)
+        self.assertIsNone(ini_config.is_ui_customization_enabled())
+
 
 # ############################################################################
 # ####### Stand-alone run ########


### PR DESCRIPTION
## QGIS global config manager

[`qgis_global_settings.ini` file](https://docs.qgis.org/latest/en/docs/user_manual/introduction/qgis_configuration.html#globalsettingsfile) contains global settings for all QGIS profile.

This PR introduces a new job `qglobal-config-manager` that can be added to a scenario to use a custom file during deployment :

```yaml
  - name: Handle the qgis_global_settings.ini file
    uses: qglobal-config-manager
    with:
      src: ./global/qgis_global_settings.ini
      dst: ~/config/qgis/global_settings.ini
```

The job handles:

- conversion of `src` and `dst` for environment variable use
- download of the `src` .ini file if the input is an url
- copy of the `src` .ini file to the `dst` .ini file
- conversion of environment variable in the `src` .ini
- define `QGIS_GLOBAL_SETTINGS_FILE` user environment variable with `dst` .ini file path

### Default values

If no value defined in jobs, default values are used. The value is defined with the same behavior as QGIS :

- first use `QGIS_GLOBAL_SETTINGS_FILE`
- if not defined, use AppDataLocation folder:
    - Linux: `$HOME/.local/share/QGIS/QGIS3/`
    - Windows  : `C:\Users\<username>\%AppData%\Roaming\QGIS\QGIS3\`
    - MacOS : `$HOME/Library/Application Support/QGIS/QGIS3/`
- if file doesn't exists : 
    - the installation directory, i.e., `your_QGIS_package_path/resources/qgis_global_settings.ini`
    - to define the QGIS package path we use `QDT_QGIS_EXE_PATH` environment variable

### Relative `src` option

`src` can be a relative path. In this case we check for .ini file related to:

- repository folder from current scenario
    - when the job `qprofiles-synchronizer` is run, all profiles repository are stored in a local repositories folder : `<qdt_working_folder>/respositories/<scenario_id>`
    - .ini file can be stored in profile repository and defined with a relative `src` : `./myprofile/qgis_global_settings.ini`
- qdt local working directory.
    - can be defined with `QDT_LOCAL_WORK_DIR` environment variable

Funded by ANFSI (cc @Niarolf ).
