### PR TITLE
Fix: script to import QDT certificate

### DIFF
--- a/scripts/qdt_crt_import.ps1
+++ b/scripts/qdt_crt_import.ps1
@@ -58,9 +58,6 @@ $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate
 
 # Add metadata to improve integration with Windows certificate manager
 $cert.FriendlyName = $friendlyName
-$cert.Extensions.Add(
-    New-Object System.Security.Cryptography.X509Certificates.X509Extension("2.5.29.17", [System.Text.Encoding]::ASCII.GetBytes($description), $false)
-)
 
 # Open the specified certificate store (LocalMachine)
 $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($storeName, $storeScope)

--- a/scripts/qdt_crt_import.ps1
+++ b/scripts/qdt_crt_import.ps1
@@ -60,8 +60,15 @@ if ($storeScope -eq "LocalMachine") {
     }
 }
 
-Invoke-WebRequest -Uri $certUrl -OutFile $localCertPath
-Write-Host "Certificate downloaded to $localCertPath"
+# download remote certificate to local path
+try {
+    Invoke-WebRequest -Uri $certUrl -OutFile $localCertPath -ErrorAction Stop
+    Write-Host "Certificate downloaded to $localCertPath"
+}
+catch {
+    Write-Error "Failed to download certificate from $certUrl"
+    exit 1
+}
 
 # Load the certificate
 $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($localCertPath)

--- a/scripts/qdt_crt_import.ps1
+++ b/scripts/qdt_crt_import.ps1
@@ -80,8 +80,18 @@ $cert.FriendlyName = $friendlyName
 $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($storeName, $storeScope)
 $store.Open("ReadWrite")
 
-# Import the certificate
-$store.Add($cert)
+# Check if certificate already exists
+$existing = $store.Certificates | Where-Object {
+   $_.Thumbprint.ToUpper() -eq $cert.Thumbprint.ToUpper()
+}
+
+if ($existing) {
+    Write-Host "Certificate already present in store."
+}
+else {
+    $store.Add($cert)
+    Write-Host "Certificate imported successfully."
+}
 $store.Close()
 
 

--- a/scripts/qdt_crt_import.ps1
+++ b/scripts/qdt_crt_import.ps1
@@ -57,7 +57,7 @@ Write-Host "Certificate downloaded to $localCertPath"
 $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($localCertPath)
 
 # Add metadata to improve integration with Windows certificate manager
-$cert.FriendlyName = "QDT Code Signing Certificate"
+$cert.FriendlyName = $friendlyName
 $cert.Extensions.Add(
     New-Object System.Security.Cryptography.X509Certificates.X509Extension("2.5.29.17", [System.Text.Encoding]::ASCII.GetBytes($description), $false)
 )

--- a/scripts/qdt_crt_import.ps1
+++ b/scripts/qdt_crt_import.ps1
@@ -45,7 +45,17 @@ if ($storeScope -eq "LocalMachine") {
     $currentUser = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
     if (-not $currentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
         Write-Warning "This script requires administrator privileges for LocalMachine scope. Relaunching with elevation..."
-        Start-Process -FilePath "powershell" -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" $args" -Verb RunAs
+        # prepare cmd args
+        $argList = @(
+            "-NoProfile",
+            "-ExecutionPolicy", "Bypass",
+            "-File", "`"$PSCommandPath`"",
+            "-storeName", $storeName,
+            "-storeScope", $storeScope,
+            "-friendlyName", "`"$friendlyName`"",
+            "-description", "`"$description`""
+        )
+        Start-Process -FilePath "powershell" -ArgumentList $argList -Verb RunAs
         exit
     }
 }


### PR DESCRIPTION
I faced various issues using this script in real conditions test so I retruned on my work PowerShell ISE table.

I've used chatGPT to help me understand the mess around the 2.5.29.17 extension.

Well, it works now:

<img width="907" height="108" alt="image" src="https://github.com/user-attachments/assets/e8498ef3-735c-4cd5-b94f-b4dc5df9684d" />

In the certmgr :

<img width="1328" height="470" alt="image" src="https://github.com/user-attachments/assets/c1ba502a-4fd3-4394-b792-dfca118d1823" />


Next step: resolve the incomplete certificates chain spotted by @NROLLANDGrandlyon 

@
