### PR TITLE
improve(security): add flag it as false positive disabling ruff warning about insecure subcmd call

### DIFF
--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -81,9 +81,10 @@ try:
     elif git_path := which("git"):
         logger.debug(f"Git executable found at: {git_path}")
         release = (
-            check_output(
+            check_output(  # noqa: S603
                 [git_path, "describe", "--tags", "--abbrev=0"],
                 cwd=Path.cwd(),
+                shell=False,
             )
             .decode()
             .strip()


### PR DESCRIPTION
See: https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/ and related issue to false positives https://github.com/astral-sh/ruff/issues/4045