### PR TITLE
update(tooling): remove 'include' coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,24 @@ show_missing = true
 
 [tool.coverage.run]
 branch = true
-include = ["qgis_deployment_toolbelt/*"]
 omit = [".venv/*", "*tests*"]
+
+[tool.pytest.ini_options]
+addopts = """
+    --junitxml=junit/test-results.xml
+    --cov-append tests/
+    --cov-config=pyproject.toml
+    --cov=qgis_deployment_toolbelt
+    --cov-report=html
+    --cov-report=term
+    --cov-report=xml
+    --ignore=tests/_wip/
+"""
+junit_family = "xunit2"
+minversion = "5.0"
+norecursedirs = ".* build dev development dist docs CVS fixtures _darcs {arch} *.egg venv _wip"
+python_files = "test_*.py"
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 88
@@ -188,23 +204,6 @@ convention = "google"
 ] # Ignore rules in Sphinx config
 "tests/test_*.py" = ["ANN001", "ANN2", "S101", "T20"] # Ignore rules in tests
 
-
-[tool.pytest.ini_options]
-addopts = """
-    --junitxml=junit/test-results.xml
-    --cov-append tests/
-    --cov-config=pyproject.toml
-    --cov=qgis_deployment_toolbelt
-    --cov-report=html
-    --cov-report=term
-    --cov-report=xml
-    --ignore=tests/_wip/
-"""
-junit_family = "xunit2"
-minversion = "5.0"
-norecursedirs = ".* build dev development dist docs CVS fixtures _darcs {arch} *.egg venv _wip"
-python_files = "test_*.py"
-testpaths = ["tests"]
 
 # Setuptools configuration
 [tool.setuptools.package-data]


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Since it's already defined in pytest-cov onfig

Warning showed up running tests: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/actions/runs/25168453001/job/73780853530?pr=809#step:6:59

See: https://coverage.readthedocs.io/en/7.13.5/messages.html#warning-include-ignored

----

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->

----

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
