### PR TITLE
chore(profiles-sync): bump dulwich minimal version to 1.2.1 and make related adjustments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "distro==1.9.* ; sys_platform == 'linux'",
-    "dulwich>=0.24.10,<0.24.11",
+    "dulwich>=1.2.1,<2",
     "giturlparse>=0.12,<0.15",
     "imagesize>=2.0.0,<2.1",
     "packaging>=22,<27",

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -21,7 +21,6 @@ from typing import Literal
 
 # 3rd party
 from dulwich import porcelain
-from dulwich.client import LsRemoteResult
 from dulwich.errors import GitProtocolError, NotGitRepository
 from dulwich.repo import Repo
 from giturlparse import GitUrlParsed, parse as git_parse, validate as git_validate
@@ -364,7 +363,7 @@ class RemoteProfilesHandlerBase:
     @proxies.os_env_proxy
     def list_remote_branches(
         self, source_repository_path_or_url: Path | str | None = None
-    ) -> tuple[str]:
+    ) -> tuple[str, ...]:
         """Retrieve git active branch from a remote repository. Mainly a checker and a
             wrapper around dulwich logic.
 
@@ -406,14 +405,13 @@ class RemoteProfilesHandlerBase:
 
         source_repository_branches = []
 
-        if isinstance(ls_remote_refs, LsRemoteResult) and len(ls_remote_refs.refs) > 0:
+        if len(ls_remote_refs.refs) > 0:
             source_repository_branches = [
                 ref.decode()
                 for ref in ls_remote_refs.refs
                 if ref.startswith(b"refs/heads/")
             ]
 
-        if source_repository_branches:
             logger.debug(
                 f"{len(source_repository_branches)} branche(s) found in repository "
                 f"{source_repository_path_or_url}: "

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -230,6 +230,10 @@ class RemoteProfilesHandlerBase:
             local_path: Path = self.SOURCE_REPOSITORY_PATH_OR_URL
 
         try:
+            logger.debug(
+                f"Trying to open local repository '{local_path.resolve()}' with "
+                "dulwich porcelain..."
+            )
             porcelain.open_repo_closing(f"{local_path.resolve()}")
             return True
         except NotGitRepository as err:
@@ -304,6 +308,9 @@ class RemoteProfilesHandlerBase:
             source_repository_path_or_url=local_git_repository_path
         )
 
+        logger.debug(
+            f"Retrieve active branch from local repository: {local_git_repository_path}"
+        )
         return porcelain.active_branch(
             repo=f"{local_git_repository_path.resolve()}"
         ).decode()
@@ -390,8 +397,11 @@ class RemoteProfilesHandlerBase:
             )
 
         # get remote branches
+        logger.debug(
+            f"Retrieving remote branches from repository: {source_repository_path_or_url}"
+        )
         ls_remote_refs: LsRemoteResult = porcelain.ls_remote(
-            remote=f"{source_repository_path_or_url}"
+            remote=f"{source_repository_path_or_url}", quiet=True
         )
 
         source_repository_branches = []
@@ -626,6 +636,7 @@ class RemoteProfilesHandlerBase:
             force=True,
             prune=True,
             prune_tags=True,
+            quiet=True,
         )
         destination_local_repository.close()
 
@@ -660,6 +671,7 @@ class RemoteProfilesHandlerBase:
             repo=local_path,
             remote_location=source_repository,
             force=True,
+            kwargs={"quiet": True},
         )
         gobj = destination_local_repository.get_object(
             destination_local_repository.head()

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -389,7 +389,8 @@ class RemoteProfilesHandlerBase:
                 f"{source_repository_path_or_url} is not a valid repository."
             )
 
-        ls_remote_refs: LsRemoteResult | dict = porcelain.ls_remote(
+        # get remote branches
+        ls_remote_refs: LsRemoteResult = porcelain.ls_remote(
             remote=f"{source_repository_path_or_url}"
         )
 
@@ -400,10 +401,6 @@ class RemoteProfilesHandlerBase:
                 ref.decode()
                 for ref in ls_remote_refs.refs
                 if ref.startswith(b"refs/heads/")
-            ]
-        elif isinstance(ls_remote_refs, dict) and len(ls_remote_refs) > 0:
-            source_repository_branches = [
-                ref.decode() for ref in ls_remote_refs if ref.startswith(b"refs/heads/")
             ]
 
         if source_repository_branches:

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -400,7 +400,7 @@ class RemoteProfilesHandlerBase:
         logger.debug(
             f"Retrieving remote branches from repository: {source_repository_path_or_url}"
         )
-        ls_remote_refs: LsRemoteResult = porcelain.ls_remote(
+        ls_remote_refs = porcelain.ls_remote(
             remote=f"{source_repository_path_or_url}", quiet=True
         )
 


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Recently [dulwich](https://github.com/jelmer/dulwich) evolved consequently.

This PR takes the time to remove legacy code and add some logs.

Next: in a future PR, I'm going to add a n option to force the dulwich log level by QDT, since it writes EVERY operation now. Memo:

```python
logging.getLogger("dulwich").setLevel(logging.WARNING)
```

Supersedes https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/813

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
