### PR TITLE
fix(about): make github_ref log contioned to not None

### DIFF
--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -67,11 +67,11 @@ __all__ = [
 # get latest git tag if possible, if not fallback to __version__
 release: str | None = None
 try:
-    github_ref = getenv("GITHUB_REF")
-    logger.info(
-        "Current branch retrieved from GitHub environment variable"
-        f"(meaning running on GitHub Actions): {github_ref=}"
-    )
+    if github_ref := getenv("GITHUB_REF"):
+        logger.info(
+            "Current branch retrieved from GitHub environment variable "
+            f"(meaning running on GitHub Actions): {github_ref=}"
+        )
     if getenv("GITHUB_REF_TYPE", "") == "tag":
         release = getenv("GITHUB_REF_NAME", None)
         logger.info(


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Just a minor fix to avoid useless logs.


Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [ ] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
