### PR TITLE
feature(settings): environment variable to customize dulwich logger

### DIFF
--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -19,12 +19,13 @@ Some options and arguments can be set with environment variables.
 
 Some others parameters can be set using environment variables.
 
-| Variable name       | Description            | Default value      |
+| Variable name       | Description              | Default value      |
 | :------------------ | :----------------------: | :----------------: |
 | `QDT_LOCAL_WORK_DIR` | Local folder where QDT download remote resources (profiles, plugins, etc.) | `~/.cache/qgis-deployment-toolbelt/default/` |
 | `QDT_LOGS_DIR` | Folder where QDT writes the log files, which are automatically rotated. | `~/.cache/qgis-deployment-toolbelt/logs/` |
 | `QDT_LOGS_DELAY_FILE_CREATION` | Delay creation of log file to the first added log. | `true` |
 | `QDT_LOGS_FILENAME` | Name of log files. The extension is part of filename so it must be set. | `{__title_clean__}_{__version_clean__}.log` i.e `QGISDeploymentToolbelt_0.40.0.log` |
+| `QDT_LOGS_DULWICH_LEVEL` | Define the log level of Git operations performed under the hood by [dulwich](https://github.com/jelmer/dulwich), which is really verbose since its version 1.2+ | `20` (= [`logging.INFO`](https://docs.python.org/3/library/logging.html#logging-levels)) |
 | `QDT_OSGEO4W_INSTALL_DIR` | Path to the OSGEO4W install directory. Used to search for installed QGIS and shortcuts creation. | `C:\\OSGeo4W`. |
 | `QDT_PAC_FILE` | Define PAC file for proxy definition. See also [How to use behind a proxy](../guides/howto_behind_proxy.md). | `` |
 | `QDT_RULES_ONLY_PREFIXED_VARIABLES` | If set to `true`, only environment variables prefixed with prefixes listed in RULES_VARIABLES_PREFIX are considered in rules for security concerns. If set to `false`, all environment variables are considered in rules. | `true` |

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -15,6 +15,7 @@ Inspired from: QGIS Resource Sharing
 
 # Standard library
 import logging
+from os import getenv
 from pathlib import Path
 from shutil import rmtree
 from typing import Literal
@@ -82,6 +83,24 @@ class RemoteProfilesHandlerBase:
         """
         self.DESTINATION_BRANCH_TO_USE = branch_to_use
         self.SOURCE_REPOSITORY_TYPE = source_repository_type
+
+        # set dulwich log level to avoid too much verbosity
+        logging.getLogger("dulwich").setLevel(int(getenv("QDT_LOGS_DULWICH_LEVEL", 20)))
+        logger.debug(
+            "Log level for dulwich (git operations) has been set to: "
+            f"{logging.getLogger('dulwich').level} "
+            f"({logging.getLevelName(logging.getLogger('dulwich').level)})."
+        )
+        # additional log if logs levels are inconsistent
+        if (
+            logger.level < logging.INFO
+            and logging.getLogger("dulwich").level > logger.level
+            and not getenv("QDT_LOGS_DULWICH_LEVEL")
+        ):
+            logger.debug(
+                "If you want full logs, set 'QDT_LOGS_DULWICH_LEVEL' "
+                "environment variable to '10'"
+            )
 
     def url_parsed(self, remote_git_url: str) -> GitUrlParsed:
         """Return URL parsed to extract git information.


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Follows-up https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/816

- set dulwich log level to 20 (INFO) see: https://docs.python.org/3/library/logging.html#logging-levels
- add an option as environment variable `QDT_LOGS_DULWICH_LEVEL` to customize dulwich log level

### Demo

Given this scenario:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/main/docs/schemas/scenario/qdt_scenario.json

metadata:
  title: "Demonstration scenario of QGIS Deployment Toolbelt"
  id: qdt-demo-scenario
  description: >-
    Demonstration scenario of QGIS Deployment Toolbelt capabilities.

# Toolbelt settings
settings:
  SCENARIO_VALIDATION: true

# Deployment workflow, step by step
steps:
  - name: Download profiles from remote git repository
    uses: qprofiles-downloader
    with:
      source: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli.git
      protocol: git_remote
      branch: main
```

Running this command:

```sh
qdt -s scenario.qdt.yml -vv
```

- Result before this PR:  [QGISDeploymentToolbelt_0.41.2.log - main](https://github.com/user-attachments/files/27405160/QGISDeploymentToolbelt_0.41.2.log)
- With this PR: [QGISDeploymentToolbelt_0.41.2.log - PR819 no option set](https://github.com/user-attachments/files/27405218/QGISDeploymentToolbelt_0.41.2.log)
- With this PR and optionset `export QDT_LOGS_DULWICH_LEVEL="10"` [QGISDeploymentToolbelt_0.41.2.log](https://github.com/user-attachments/files/27405267/QGISDeploymentToolbelt_0.41.2.log)



Funded by Oslandia
<!-- osl:grant-oss-2026 -->


## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
