### PR TITLE
improve(jobs): move os_config attribute from __init__ to a cached property

### DIFF
--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -13,7 +13,7 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from os import getenv
 from pathlib import Path
 
@@ -55,8 +55,6 @@ class GenericJob:
 
     def __init__(self) -> None:
         """Object instanciation."""
-        # operating system configuration
-        self.os_config = OSConfiguration.from_opersys()
 
         # QDT rules context
         only_prefixed_variables = str2bool(
@@ -93,6 +91,17 @@ class GenericJob:
             self.qgis_profiles_path.mkdir(parents=True)
         logger.debug(f"Installed QGIS profiles folder: {self.qgis_profiles_path}")
 
+    # -- Properties
+    @cached_property
+    def os_config(self) -> OSConfiguration:
+        """Get current operating system configuration.
+
+        Returns:
+            OSConfiguration: object with settings regarding operating system and QGIS
+        """
+        return OSConfiguration.from_opersys()
+
+    # -- Methods
     def list_downloaded_profiles(self) -> tuple[QdtProfile] | None:
         """List downloaded QGIS profiles, i.e. a profile's folder located into the QDT
             working folder.


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Goal: solving redundant calls using [cached property](https://docs.python.org/fr/3.14/library/functools.html#functools.cached_property) and avoiding I/O within init since every child class will run those same ops

Funded by Oslandia
<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
