### PR TITLE
fix(jobs): options validation was using bad condition type to raise error

### DIFF
--- a/qgis_deployment_toolbelt/exceptions.py
+++ b/qgis_deployment_toolbelt/exceptions.py
@@ -21,7 +21,7 @@ class JobOptionBadNameError(KeyError):
         Args:
             job_id (str): job ID
             bad_option_name (str): name of bad option passed
-            expected_options_names (Iterable[str]): _description_
+            expected_options_names (Iterable[str]): list of accepted options
         """
         self.message = (
             f"Job: {job_id}. Option '{bad_option_name}' is not valid. "
@@ -40,21 +40,21 @@ class JobOptionBadValueError(ValueError):
         bad_option_name: str,
         bad_option_value: str,
         condition: str,
-        accepted_values: Iterable[str],
+        accepted_values: Iterable[str] | None = None,
     ):
         """Initialization method.
 
         Args:
             job_id (str): job ID
             bad_option_name (str): name of bad option passed
-            bad_option_type (str): name of bad option passed
+            bad_option_type (str): type of bad option passed
             condition (str): condition
-            accepted_values (Iterable[str]): accepted types of values
+            accepted_values (Iterable[str] | None, optional): accepted types of values. Defaults to None.
         """
         self.message = (
             f"Job: {job_id}. Option '{bad_option_name}' 's value '{bad_option_value}' "
             f"does not comply with condition {condition}. "
-            f"Accepted pattern: {','.join(accepted_values)}"
+            f"Accepted pattern: {','.join(accepted_values) if accepted_values else 'no defined'}"
         )
 
         super().__init__(self.message)
@@ -75,7 +75,7 @@ class JobOptionBadValueTypeError(TypeError):
         Args:
             job_id (str): job ID
             bad_option_name (str): name of bad option passed
-            bad_option_value (str): option's value
+            bad_option_value (str): value of bad option passed
             expected_option_type (Iterable[str]): accepted types of values
         """
         self.message = (
@@ -100,7 +100,7 @@ class SplashScreenBadDimensionsError(Exception):
         self.message = (
             f"Profile {profile_name} -"
             f"{image_filepath.resolve()} dimensions "
-            f"{get_image_size(image_filepath=image_filepath)} do not comply with "
+            f"{get_image_size(image_filepath=image_filepath)} does not comply with "
             " dimensions recomended by QGIS for splash screen: 600x300."
         )
         super().__init__(self.message)

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -76,7 +76,12 @@ class GenericJob:
         self.qdt_downloaded_repositories = self.qdt_working_folder.joinpath(
             f"repositories/{getenv('QDT_TMP_RUNNING_SCENARIO_ID', 'default')}"
         )
+        logger.debug(
+            f"Current scenario repository folder: {self.qdt_downloaded_repositories}"
+        )
+
         self.qdt_plugins_folder = self.qdt_working_folder.joinpath("plugins")
+        logger.debug(f"QDT local plugins cache folder: {self.qdt_plugins_folder}")
 
         # destination profiles folder
         self.qgis_profiles_path: Path = self.os_config.qgis_profiles_path

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -299,7 +299,7 @@ class GenericJob:
                     job_id=self.ID,
                     bad_option_name=option,
                     bad_option_value=option_in,
-                    condition="startswith",
+                    condition="in",
                     accepted_values=option_def.get("possible_values"),
                 )
             else:

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -16,6 +16,7 @@ import logging
 from functools import cached_property, lru_cache
 from os import getenv
 from pathlib import Path
+from typing import Any
 
 # 3rd party
 from python_rule_engine import RuleEngine
@@ -51,7 +52,7 @@ class GenericJob:
     """Generic base for QDT jobs."""
 
     ID: str = ""
-    OPTIONS_SCHEMA: dict[dict] = dict(dict())
+    OPTIONS_SCHEMA: dict[str, dict[str, Any]] = {}
 
     def __init__(self) -> None:
         """Object instanciation."""
@@ -252,58 +253,66 @@ class GenericJob:
 
         return li_profiles_matched, li_profiles_unmatched
 
-    def validate_options(self, options: dict[dict]) -> dict[dict]:
-        """Validate options.
+    def validate_options(self, options: dict[str, Any]) -> dict[str, Any]:
+        """Validate job options against ``OPTIONS_SCHEMA``.
 
         Args:
-            options (dict[dict]): options to validate.
+            options (dict[str, Any]): options to validate
 
         Raises:
-            ValueError: if option has an invalid name or doesn't comply with condition
-            TypeError: if the option does'nt not comply with expected type
+            JobOptionBadNameError: if an option name is not in the schema
+            JobOptionBadValueError: if an option value fails its condition
+            JobOptionBadValueTypeError: if an option value has the wrong type
+            TypeError: if options is not a dict
 
         Returns:
-            dict[dict]: options if valid
+            dict[str, Any]: unchanged when all checks pass
         """
         if not isinstance(options, dict):
             raise TypeError(f"Options to validate must be a dict, not {type(options)}.")
 
-        for option in options:
-            if option not in self.OPTIONS_SCHEMA:
+        for option_name, option_value in options.items():
+            if option_name not in self.OPTIONS_SCHEMA:
                 raise JobOptionBadNameError(
                     job_id=self.ID,
-                    bad_option_name=option,
+                    bad_option_name=option_name,
                     expected_options_names=self.OPTIONS_SCHEMA.keys(),
                 )
 
-            option_in = options.get(option)
-            option_def: dict = self.OPTIONS_SCHEMA.get(option)
+            option_def: dict[str, Any] = self.OPTIONS_SCHEMA[option_name]
+
             # check value type
-            if not isinstance(option_in, option_def.get("type")):
+            if not isinstance(option_value, option_def["type"]):
                 raise JobOptionBadValueTypeError(
                     job_id=self.ID,
-                    bad_option_name=option,
-                    bad_option_value=option_in,
-                    expected_option_type=option_def.get("type"),
+                    bad_option_name=option_name,
+                    bad_option_value=option_value,
+                    expected_option_type=option_def["type"],
                 )
+
             # check value condition
-            if option_def.get("condition") == "startswith" and not option_in.startswith(
-                option_def.get("possible_values")
+            option_condition: str | None = option_def.get("condition")
+            option_possible_values: tuple[str, ...] | None = option_def.get(
+                "possible_values"
+            )
+
+            if option_condition == "startswith" and not option_value.startswith(
+                option_possible_values
             ):
                 raise JobOptionBadValueError(
                     job_id=self.ID,
-                    bad_option_name=option,
-                    bad_option_value=option_in,
+                    bad_option_name=option_name,
+                    bad_option_value=option_value,
                     condition="startswith",
-                    accepted_values=option_def.get("possible_values"),
+                    accepted_values=option_possible_values,
                 )
-            elif option_def.get(
-                "condition"
-            ) == "in" and option_in not in option_def.get("possible_values"):
+            elif (
+                option_condition == "in" and option_value not in option_possible_values
+            ):
                 raise JobOptionBadValueError(
                     job_id=self.ID,
-                    bad_option_name=option,
-                    bad_option_value=option_in,
+                    bad_option_name=option_name,
+                    bad_option_value=option_value,
                     condition="in",
                     accepted_values=option_def.get("possible_values"),
                 )

--- a/qgis_deployment_toolbelt/profiles/rules_context.py
+++ b/qgis_deployment_toolbelt/profiles/rules_context.py
@@ -66,6 +66,8 @@ class QdtRulesContext:
         else:
             self.variables_prefix = variables_prefix
 
+        logger.debug(f"Environment variables prefixes: {self.variables_prefix}")
+
     @property
     def _context_date(self) -> dict:
         """Returns a context dictionary with date informations that can be used in QDT


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Working on #781, I realized that options validation contains a minor bug: "startswith" was used instead of "in" in the relevant exception block.

Then I decided to continue on quality improvements on the GenericJob class and I refined logs, docstrings and type hints.

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
