### PR TITLE
improve(jobs-rules): add a minimalist cache mechanism to rules evaluation to make result persisting between jobs

### DIFF
--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -13,7 +13,7 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
-from functools import cached_property, lru_cache
+from functools import cached_property
 from os import getenv
 from pathlib import Path
 from typing import Any
@@ -53,6 +53,10 @@ class GenericJob:
 
     ID: str = ""
     OPTIONS_SCHEMA: dict[str, dict[str, Any]] = {}
+
+    RULES_FILTER_CACHE: dict[
+        tuple[Path, ...], tuple[list[QdtProfile], list[QdtProfile]]
+    ] = {}
 
     def __init__(self) -> None:
         """Object instanciation."""
@@ -204,22 +208,45 @@ class GenericJob:
         )
         return qdt_profile
 
-    @lru_cache(maxsize=1024)  # noqa: B019
     def filter_profiles_on_rules(
-        self, tup_qdt_profiles: tuple[QdtProfile]
+        self, tup_qdt_profiles: tuple[QdtProfile, ...], cached: bool = True
     ) -> tuple[list[QdtProfile], list[QdtProfile]]:
-        """Evaluate profile regarding to its deployment rules.
+        """Evaluate profile regarding to its deployment rules. Results are stored in
+        the class ``RULES_FILTER_CACHE`` attribute.
 
         Args:
-            tup_qdt_profiles (tuple[QdtProfile]): input tuple of QDT profiles
+            tup_qdt_profiles (tuple[QdtProfile, ...]): input tuple of QDT profiles
+            cached (bool, optional): using previously computed value if not None.
+                Defaults to True.
 
         Returns:
-            tuple[list[QdtProfile], list[QdtProfile]]: tuple of profiles that matched
+            tuple[QdtProfile], list[QdtProfile]]: tuple of profiles that matched
             and those which did not match their deployment rules
         """
-        li_profiles_matched = []
-        li_profiles_unmatched = []
+        # check previous cached result
+        if cached:
+            cache_key: tuple[Path, ...] = tuple(
+                p.folder for p in tup_qdt_profiles if isinstance(p.folder, Path)
+            )
+            if cache_key in self.RULES_FILTER_CACHE:
+                logger.debug(
+                    f"Profiles '{cache_key}' have "
+                    "already been evaluated, returning previous result. "
+                    "Use 'cached=False' to force re-checking."
+                )
+                return self.RULES_FILTER_CACHE[cache_key]
+            logger.debug(
+                f"Profiles '{cache_key}' have not been evaluated yet, checking rules..."
+            )
+        else:
+            logger.debug("Profiles rules evaluation forced, checking rules...")
 
+        # local vars
+        li_profiles_matched: list[QdtProfile] = []
+        li_profiles_unmatched: list[QdtProfile] = []
+        rules_context = self.qdt_rules_context.to_dict()
+
+        # checking each profile against rules
         for profile in tup_qdt_profiles:
             if profile.rules is None:
                 logger.debug(f"No rules to apply to {profile.name}")
@@ -232,10 +259,11 @@ class GenericJob:
             )
             try:
                 engine = RuleEngine(rules=profile.rules)
-                results = engine.evaluate(obj=self.qdt_rules_context.to_dict())
+                results = engine.evaluate(obj=rules_context)
                 if len(results) == len(profile.rules):
                     logger.debug(
-                        f"Profile '{profile.name}' matches {len(profile.rules)} deployment rule(s)."
+                        f"Profile '{profile.name}' matches {len(profile.rules)} "
+                        "deployment rule(s)."
                     )
                     li_profiles_matched.append(profile)
                 else:
@@ -248,9 +276,15 @@ class GenericJob:
 
             except Exception as err:
                 logger.error(
-                    f"Error occurred parsing rules of profile '{profile.name}'. Trace: {err}"
+                    f"Error occurred parsing rules of profile '{profile.name}'. "
+                    f"Trace: {err}"
                 )
 
+        # store result for other jobs that would need it later
+        self.RULES_FILTER_CACHE[cache_key] = (
+            li_profiles_matched,
+            li_profiles_unmatched,
+        )
         return li_profiles_matched, li_profiles_unmatched
 
     def validate_options(self, options: dict[str, Any]) -> dict[str, Any]:

--- a/qgis_deployment_toolbelt/profiles/qdt_profile.py
+++ b/qgis_deployment_toolbelt/profiles/qdt_profile.py
@@ -197,7 +197,7 @@ class QdtProfile:
         return self._alias
 
     @property
-    def folder(self) -> Path:
+    def folder(self) -> Path | None:
         """Returns the path to the folder where the profile is stored.
 
         Returns:

--- a/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
@@ -12,7 +12,6 @@ metadata:
 
 settings:
   DEBUG: false
-  LOCAL_WORK_DIR: ~/.cache/qgis-deployment-toolbelt/tests/
   SCENARIO_VALIDATION: true
 
 steps:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -125,7 +125,7 @@ def test_main_run_no_log_file(capsys):
     """Test main cli command without log file"""
 
     with tempfile.TemporaryDirectory(
-        prefix="QDT_test_cli_run_no_log_file",
+        prefix="QDT_test_cli_run_no_log_file_",
         ignore_cleanup_errors=True,
     ) as tmpdirname:
         # customize QDT working folder and profiles destination folder
@@ -167,7 +167,7 @@ def test_main_run_log_filename(capsys):
     """Test main cli command with log filename definition"""
 
     with tempfile.TemporaryDirectory(
-        prefix="QDT_test_cli_run_log_filename",
+        prefix="QDT_test_cli_run_log_filename_",
         ignore_cleanup_errors=True,
     ) as tmpdirname:
         # customize QDT working folder and profiles destination folder
@@ -185,6 +185,7 @@ def test_main_run_log_filename(capsys):
                     "deploy",
                     "--logs-filename=custom_qdt_logfile.log",
                     f"--scenario={sample_scenario_good.resolve()}",
+                    "-vv",
                 ]
             )
 


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Goal: solving redundant calls

AI: I had an error (inconsistent behavior) on the cache key. I asked claude.ai to find out. It helped me understand why `__eq__` and `__hash__` on `QdtProfile` are not reliable for this use-case.

Funded by Oslandia <!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
