### PR TITLE
fix(jobs-rules): cache_key has to defined even if cached is False because it's used to store the cache at the method end

### DIFF
--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -224,10 +224,10 @@ class GenericJob:
             and those which did not match their deployment rules
         """
         # check previous cached result
+        cache_key: tuple[Path, ...] = tuple(
+            p.folder for p in tup_qdt_profiles if isinstance(p.folder, Path)
+        )
         if cached:
-            cache_key: tuple[Path, ...] = tuple(
-                p.folder for p in tup_qdt_profiles if isinstance(p.folder, Path)
-            )
             if cache_key in self.RULES_FILTER_CACHE:
                 logger.debug(
                     f"Profiles '{cache_key}' have "


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Follows-up https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/827

Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
