### PR TITLE
add(utils): helper to determine filename from URL

### DIFF
--- a/qgis_deployment_toolbelt/commands/deployment.py
+++ b/qgis_deployment_toolbelt/commands/deployment.py
@@ -16,7 +16,6 @@ import logging
 from os import environ, getenv
 from pathlib import Path
 from sys import platform as opersys
-from urllib.parse import urlsplit
 
 # submodules
 from qgis_deployment_toolbelt.constants import (
@@ -28,8 +27,8 @@ from qgis_deployment_toolbelt.scenarios import ScenarioReader
 from qgis_deployment_toolbelt.utils.bouncer import exit_cli_error, exit_cli_success
 from qgis_deployment_toolbelt.utils.check_path import check_path
 from qgis_deployment_toolbelt.utils.file_downloader import download_remote_file_to_local
-from qgis_deployment_toolbelt.utils.slugger import sluggy
 from qgis_deployment_toolbelt.utils.str2bool import str2bool
+from qgis_deployment_toolbelt.utils.url_helpers import filename_from_url
 
 
 # #############################################################################
@@ -53,14 +52,9 @@ def get_remote_scenario_from_url(remote_url: str) -> Path:
     Returns:
         Path: local path to downloaded scenario.
     """
-    # try to build file path from URL
     try:
-        url_splitted = urlsplit(remote_url)
         local_filepath_for_remote_scenario = (
-            "remote_scenarios/"
-            f"{sluggy(url_splitted.netloc)}/"
-            f"{sluggy(str(Path(url_splitted.path).parent))}/"
-            f"{Path(url_splitted.path).name}"
+            f"remote_scenarios/{filename_from_url(remote_url)}"
         )
     except Exception as err:
         local_filepath_for_remote_scenario = "remote_scenarios/default/scenario.qdt.yml"

--- a/qgis_deployment_toolbelt/utils/url_helpers.py
+++ b/qgis_deployment_toolbelt/utils/url_helpers.py
@@ -12,7 +12,11 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
-from urllib.parse import urlparse
+from pathlib import PurePosixPath
+from urllib.parse import urlparse, urlsplit
+
+# package
+from qgis_deployment_toolbelt.utils.slugger import sluggy
 
 
 # #############################################################################
@@ -75,10 +79,33 @@ def check_str_is_url(
         return False
 
 
-# ############################################################################
-# ##### Stand alone program ########
-# ##################################
+def filename_from_url(url: str) -> str:
+    """Try to determine filename from a given download URL.
 
-if __name__ == "__main__":
-    """Standalone execution."""
-    pass
+    Args:
+        url (str): URL to remote file
+
+    Returns:
+        str: determined filename
+    """
+    url_splitted = urlsplit(url)
+
+    url_host = sluggy(url_splitted.netloc)
+    url_path = PurePosixPath(url_splitted.path)
+    url_file_parent = url_path.parent
+    url_file_name = url_path.name
+
+    if url_file_parent in (PurePosixPath("/"), PurePosixPath("."), PurePosixPath("")):
+        parent_slug = ""
+    else:
+        parent_slug = sluggy(str(url_file_parent).lstrip("/"))
+
+    segments = [url_host]
+
+    if parent_slug:
+        segments.append(parent_slug)
+
+    if url_file_name:
+        segments.append(url_file_name)
+
+    return "/".join(segments)

--- a/tests/test_utils_url_helpers.py
+++ b/tests/test_utils_url_helpers.py
@@ -16,7 +16,10 @@ from pathlib import Path
 
 # project
 from qgis_deployment_toolbelt.__about__ import __uri__
-from qgis_deployment_toolbelt.utils.url_helpers import check_str_is_url
+from qgis_deployment_toolbelt.utils.url_helpers import (
+    check_str_is_url,
+    filename_from_url,
+)
 
 
 # ############################################################################
@@ -38,6 +41,31 @@ class TestUtilsUrlHelpers(unittest.TestCase):
 
         with self.assertRaises((TypeError, ValueError)):
             check_str_is_url(input_str=Path(__file__), raise_error=True)
+
+    def test_url_basic(self):
+        """Test basic url to filename."""
+        url = "https://qdt.com/files/data.txt"
+        self.assertEqual(filename_from_url(url), "qdtcom/files/data.txt")
+
+    def test_url_file_at_root(self):
+        """Test url with file at root."""
+        url = "https://github.com/data.txt"
+        self.assertEqual(filename_from_url(url), "githubcom/data.txt")
+
+    def test_url_nested_path(self):
+        """Test url with subdomain."""
+        url = "https://sub.oslandia.com/a/b/c/file.zip"
+        self.assertEqual(filename_from_url(url), "suboslandiacom/abc/file.zip")
+
+    def test_url_accents_and_spaces(self):
+        """Test url with special chars, keeping them in filename."""
+        url = "https://mälmo.com/dossier été/fîlé nâmé.txt"
+        self.assertEqual(filename_from_url(url), "malmocom/dossier-ete/fîlé nâmé.txt")
+
+    def test_url_query_string(self):
+        """Test cleaning query rom url."""
+        url = "https://example.com/files/data.txt?token=123"
+        self.assertEqual(filename_from_url(url), "examplecom/files/data.txt")
 
 
 # ############################################################################


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Working on #781 I find that we should factorize this URL manipulation, already done in deployment.py: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/6ea5eef5ad23ffd7b28849327b6f463ae421aa25/qgis_deployment_toolbelt/jobs/job_qglobal_config_manager.py#L258-L274

Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
