### PR TITLE
fix(logs): remove unwanted logs in packaged mode

### DIFF
--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -11,7 +11,7 @@ from importlib import metadata
 from os import getenv
 from pathlib import Path
 from shutil import which
-from subprocess import check_output
+from subprocess import DEVNULL, check_output
 
 
 logger = logging.getLogger(__name__)
@@ -85,6 +85,7 @@ try:
                 [git_path, "describe", "--tags", "--abbrev=0"],
                 cwd=Path.cwd(),
                 shell=False,
+                stderr=DEVNULL,
             )  # nosec B603
             .decode()
             .strip()

--- a/qgis_deployment_toolbelt/utils/frozen_app.py
+++ b/qgis_deployment_toolbelt/utils/frozen_app.py
@@ -61,7 +61,7 @@ def is_running_pyinstaller(log: bool = True) -> bool:
     Returns:
         bool: True if executed from a PyInstaller-built executable, False otherwise.
     """
-    is_pyinstaller = is_frozen_app() and hasattr(sys, "_MEIPASS")
+    is_pyinstaller = is_frozen_app(log=log) and hasattr(sys, "_MEIPASS")
     if not log:
         return is_pyinstaller
     if is_pyinstaller:


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

2 minor fixes:

- fix(logs): propagate log option in frozen_app
- fix(logs): make git subcmd quiet to remove unwanted log. In packaged mode, qdt was systematically printing:

```sh
fatal : ni ceci ni aucun de ses répertoires parents n'est un dépôt git : .git"
```

Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
