### PR TITLE
improve(packaging): address some warnings during PyInstaller builds

### DIFF
--- a/builder/pyinstaller_build_ubuntu.py
+++ b/builder/pyinstaller_build_ubuntu.py
@@ -12,7 +12,7 @@ Launch PyInstaller using a Python script.
 import platform
 import sys
 from datetime import datetime
-from os import getenv
+from os import environ, getenv
 from pathlib import Path
 
 # 3rd party
@@ -29,6 +29,11 @@ from qgis_deployment_toolbelt import __about__  # noqa: E402
 # #############################################################################
 # ########### MAIN #################
 # ##################################
+
+# force C locale to avoid encoding issues with PyInstaller building on systems with other locales (e.g. fr_FR.UTF-8)
+# see: https://github.com/pyinstaller/pyinstaller/issues/5540
+environ["LANG"] = "C"
+environ["LC_ALL"] = "C"
 
 # write build report
 build_report = (
@@ -57,8 +62,8 @@ PyInstaller.__main__.run(
     [
         "--add-data=LICENSE:.",
         "--add-data=README.md:.",
-        f"--add-data={Path(__file__).parent / 'build' / 'tldextract_cache'/ '.suffix_cache'}:tldextract/.suffix_cache",
-        f"--add-data={Path(__file__).parent / 'build' / 'tldextract_cache'/'.tld_set_snapshot'}:tldextract/",
+        f"--add-data={Path(__file__).parent / 'build' / 'tldextract_cache' / '.suffix_cache'}:tldextract/.suffix_cache",
+        f"--add-data={Path(__file__).parent / 'build' / 'tldextract_cache' / '.tld_set_snapshot'}:tldextract/",
         f"--add-data={package_folder.joinpath('shortcuts/shortcut_freedesktop.template').resolve()}:shortcuts/",
         f"--log-level={getenv('PYINSTALLER_LOG_LEVEL', 'WARN')}",
         f"--name={output_filename}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ packaging = [
     "pyinstaller>=6.20,<6.21",
     "pyinstaller-hooks-contrib>=2025,<2027",
     "pypiwin32==223 ; sys_platform == 'win32'",
+    "tzdata>=2026 ; sys_platform == 'win32'",
 ]
 
 security = ["bandit[toml]>=1.8.3,<2", "safety>=3.3.1,<4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ doc = [
 ]
 
 packaging = [
-    "pyinstaller>=6.13,<6.21",
+    "pyinstaller>=6.20,<6.21",
     "pyinstaller-hooks-contrib>=2025,<2027",
     "pypiwin32==223 ; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

- bump minimal PyInstaller version to 6.20
- address warning about tzdata on Windows
- address warning about locale on Linux

I also wanted to fix the warning about charset-normalizer on Ubuntu (`17773 WARNING: Hidden import "charset_normalizer.md__mypyc" not found!` matching https://charset-normalizer.readthedocs.io/en/latest/community/faq.html#i-can-t-build-standalone-executable and https://stackoverflow.com/questions/74182807/no-module-named-charset-normalizer-md-mypyc) but I did not find how to do it in an elegant way. I tried with claude.ai but it did not find out neither.

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
