### PR TITLE
fix(profiles-sync): pull was ignoring local branch and clear cache when needed

### DIFF
--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -704,10 +704,28 @@ class RemoteProfilesHandlerBase:
         logger.info(f"Pulling repository {source_repository} to {local_path}")
 
         destination_local_repository = Repo(root=f"{local_path.resolve()}")
+
+        # get branch to pull
+        branch: str | None = None
+        if self.DESTINATION_BRANCH_TO_USE:
+            branch = (
+                self.DESTINATION_BRANCH_TO_USE
+                if isinstance(self.DESTINATION_BRANCH_TO_USE, str)
+                else self.DESTINATION_BRANCH_TO_USE.decode()
+            )
+            logger.debug(f"Branch to pull (from class): {branch}")
+        else:
+            branch = self.get_active_branch_from_local_repository(
+                local_git_repository_path=local_path
+            )
+            logger.debug(f"Branch to pull (from local repository): {branch}")
+
+        # pulling remote
         porcelain.pull(
             repo=local_path,
             remote_location=source_repository,
             force=True,
+            refspecs=branch,
             kwargs={"quiet": True},
         )
         gobj = destination_local_repository.get_object(

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -471,7 +471,9 @@ class RemoteProfilesHandlerBase:
 
         return local_git_repository
 
-    def clone_or_pull(self, to_local_destination_path: Path, attempt: int = 1) -> Repo:
+    def clone_or_pull(
+        self, to_local_destination_path: Path, attempt: int = 1
+    ) -> Repo | None:
         """Clone or fetch/pull remote repository to local path. If this one doesn't exist,
         it's created. If fetch or pull action fail, it removes the existing folder and
         clone the remote again.
@@ -498,7 +500,25 @@ class RemoteProfilesHandlerBase:
         ):
             try:
                 logger.debug("Start cloning operations...")
-                return self._clone(local_path=to_local_destination_path)
+                cloned_repo = self._clone(local_path=to_local_destination_path)
+                logger.debug(
+                    f"{self.SOURCE_REPOSITORY_PATH_OR_URL} has been successfully cloned "
+                    f"locally: {to_local_destination_path}."
+                )
+                # update cache
+                if to_local_destination_path in self.CACHE_INVALID_GIT_REPOSITORIES:
+                    self.CACHE_INVALID_GIT_REPOSITORIES.remove(
+                        to_local_destination_path
+                    )
+                    logger.debug(
+                        f"Cache updated: {to_local_destination_path} removed from invalid repositories."
+                    )
+                if to_local_destination_path not in self.CACHE_VALID_GIT_REPOSITORIES:
+                    self.CACHE_VALID_GIT_REPOSITORIES.append(to_local_destination_path)
+                    logger.debug(
+                        f"Cache updated: {to_local_destination_path} added to valid repositories."
+                    )
+                return cloned_repo
             except Exception as err:
                 logger.error(
                     "Error cloning the source repository "

--- a/tests/test_git_handler_local.py
+++ b/tests/test_git_handler_local.py
@@ -170,3 +170,34 @@ class TestGitHandlerLocal(unittest.TestCase):
             target_repo = local_git_handler.download(
                 destination_local_path=repo_in_temporary_folder
             )
+
+    def test_clone_then_pull_respects_branch(self):
+        """Test that _pull checks out the requested branch, not the remote default."""
+        # specify 'main'
+        local_git_handler = LocalGitHandler(
+            source_repository_path_or_uri=self.source_git_path_source,
+            branch_to_use="main",
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_local_git_",
+            ignore_cleanup_errors=True,
+            suffix="_pull_branch_check",
+        ) as tmpdirname:
+            repo_path = Path(tmpdirname)
+
+            # first clone
+            local_git_handler.download(destination_local_path=repo_path)
+            self.assertTrue(repo_path.joinpath(".git").is_dir())
+
+            # try again, fetch and pull
+            target_repo = local_git_handler.download(destination_local_path=repo_path)
+            self.assertIsInstance(target_repo, Repo)
+
+            # the active branch has to match the one we specified, not the default one
+            # of the remote repository
+            active_branch = local_git_handler.get_active_branch_from_local_repository(
+                local_git_repository_path=repo_path
+            )
+            self.assertEqual(active_branch, "main")
+            self.assertEqual(active_branch, local_git_handler.DESTINATION_BRANCH_TO_USE)


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Working on #781 where @jmkerloch changed the branch specified in default scenario, I faced the case where QDT (dulwich under the hood) was not using the branch specified in the scenario nor the one which was previously used to clone.

I add a small test but I think we should work later on an extended version to handle a more realistic use case.


Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
