### PR TITLE
feature(autocompletion): enable CLI autocompletion using argcomplete

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,20 +56,20 @@ jobs:
           python -m pip install -U pip setuptools wheel
 
       - name: Install project as a package
-        run: python -m pip install -e .
+        run: python -m pip install -e .[completion]
 
       # this job must run before installing other dependencies to avoid listing everything
       - name: Generates dependencies graph page with pipdetree
         run: |
-          python -m pip install -U "pipdeptree<3"
+          python -m pip install -U pipdeptree
           echo -e "\`\`\`{mermaid}" > docs/misc/dependencies.md
-          pipdeptree --exclude pip,pipdeptree,setuptools,wheel --mermaid >> docs/misc/dependencies.md
+          pipdeptree --exclude pip,pipdeptree,setuptools,wheel --extras -o mermaid >> docs/misc/dependencies.md
           echo -e "\`\`\`" >> docs/misc/dependencies.md
 
       # this job must run before installing other dependencies to avoid listing everything
       - name: Generates licenses page with pip-licences
         run: |
-          python -m pip install -U "pip-licenses<5"
+          python -m pip install -U pip-licenses
           pip-licenses --format=markdown --with-authors --with-description --with-urls --ignore-packages qgis-deployment-toolbelt --output-file=docs/misc/licenses.md
 
       - name: Install documentation requirements

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           python -m pip install -U pip setuptools wheel
 
       - name: Install project as a package
-        run: python -m pip install -e .[test]
+        run: python -m pip install -e .[completion,test]
 
       - name: Unit tests
         env:
@@ -137,7 +137,7 @@ jobs:
           python -m pip install -U pip setuptools wheel
 
       - name: Install project as a package
-        run: python -m pip install -e .[test]
+        run: python -m pip install -e .[completion,test]
 
       - name: QDT - Echoing help
         run: qdt --help
@@ -160,6 +160,10 @@ jobs:
 
       - name: QDT - Export rules context
         run: qdt export-rules-context -o rules_context/"${{ matrix.os }}_${{ matrix.python-version }}.json"
+
+      - name: QDT - Display completion help
+        run: |
+          qdt completion
 
       - name: Save Rules Context as artifact
         uses: actions/upload-artifact@v7

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,8 +133,10 @@ intersphinx_mapping = {
 # -- Extension configuration -------------------------------------------------
 
 # argparse
+sphinxarg_full_subcommand_name = True
 sphinxarg_build_commands_index = True
 sphinxarg_commands_index_in_toctree = True
+sphinxarg_build_commands_by_group_index = False
 
 # autodoc
 autodoc_default_options = {

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -93,7 +93,7 @@ Look for the latest released version and compare it with the running one.
 > - Powershell 5+:
 >
 >   ```powershell
->   Register-PythonArgcomplete qdt | Out-String | Invoke-Expression
+>   register-python-argcomplete --shell powershell qdt | Out-String | Invoke-Expression
 >   ```
 
 :::{note}

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -4,9 +4,7 @@ Aliases : `qdt`, `qgis-deployment-toolbelt`, `qdeploy-toolbelt`
 
 ## deploy
 
-:::{tip}
-This subcommand is defined as default. So `qdt -s [...]` is equivalent to `qdt deploy -s [...]`
-:::
+> Running a scenario deployment.
 
 ```{argparse}
   :module: qgis_deployment_toolbelt.cli
@@ -15,7 +13,15 @@ This subcommand is defined as default. So `qdt -s [...]` is equivalent to `qdt d
   :prog: qdt
 ```
 
+:::{tip}
+This subcommand is defined as default. So `qdt -s [...]` is equivalent to `qdt deploy -s [...]`
+:::
+
+----
+
 ## export-rules-context
+
+> Export rules context in a JSON file.
 
 ```{argparse}
   :module: qgis_deployment_toolbelt.cli
@@ -24,11 +30,79 @@ This subcommand is defined as default. So `qdt -s [...]` is equivalent to `qdt d
   :prog: qdt
 ```
 
+----
+
 ## upgrade
+
+:::{note}
+Look for the latest released version and compare it with the running one.
+:::
+
+```{argparse}
+  :description:
+  :module: qgis_deployment_toolbelt.cli
+  :func: build_parser
+  :path: upgrade
+  :prog: qdt
+```
+
+----
+
+## completion
+
+> Print instructions on enabling shell completions for QDT.
+>
+> If you encountered register-python-argcomplete command not found error, run:
+>
+> ```sh
+> pipx install 'qgis-deployment-toolbelt[completion]'
+> ```
+>
+> or if you already installed QDT with pipx:
+>
+>
+> ```sh
+> pipx inject qgis-deployment-toolbelt argcomplete
+> ```
+>
+> - Bash: typically add to `~/.bashrc` or `~/.profile`:
+>
+>   ```bash
+>   eval "$(register-python-argcomplete qdt)"
+>   eval "$(register-python-argcomplete qgis-deployment-toolbelt)"
+>   ```
+>
+> - zsh: to activate completions in zsh, first make sure `compinit` is enabled:
+>
+>   ```zsh
+>   autoload -U compinit && compinit
+>   ```
+>
+>   Afterwards you can enable completions:
+>
+>   ```zsh
+>   eval "$(register-python-argcomplete qdt)"
+>   ```
+>
+> - fish:
+>
+>   ```fish
+>   register-python-argcomplete --shell fish qdt >~/.config/fish/completions/qdt.fish
+>   ```
+>
+> - Powershell 5+:
+>
+>   ```powershell
+>   Register-PythonArgcomplete qdt | Out-String | Invoke-Expression
+>   ```
+
+:::{note}
+CLI autocompletions are not available in "frozen" binaries in official releases.
+:::
 
 ```{argparse}
   :module: qgis_deployment_toolbelt.cli
   :func: build_parser
-  :path: upgrade
+  :path: completion
   :prog: qdt
 ```

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -41,7 +41,7 @@ MacOS version is not tested and is just here to encourage beta-testing and feedb
 ```sh
 # bare
 pipx install qgis-deployment-toolbelt
-# to have completion commande
+# to have completion commands
 pipx install qgis-deployment-toolbelt[completion]
 ```
 

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -36,7 +36,16 @@ MacOS version is not tested and is just here to encourage beta-testing and feedb
 
 - Python 3.10+
 
-### Step-by-step
+### Using [pipx](https://pipx.pypa.io/) (recommended)
+
+```sh
+# bare
+pipx install qgis-deployment-toolbelt
+# to have completion commande
+pipx install qgis-deployment-toolbelt[completion]
+```
+
+### Using pip
 
 The package is installable with pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+completion = ["argcomplete>=3.6.3,<4"]
+
 dev = ["ruff>=0.13.1", "pre-commit>=4,<5"]
 
 doc = [

--- a/qgis_deployment_toolbelt/cli.py
+++ b/qgis_deployment_toolbelt/cli.py
@@ -1,4 +1,5 @@
 #! python3  # noqa: E265
+# PYTHON_ARGCOMPLETE_OK
 # Copyright 2023 Julien Moura (Oslandia)
 # SPDX-License-Identifier: Apache-2.0
 
@@ -27,6 +28,10 @@ from qgis_deployment_toolbelt.__about__ import (
     __uri_homepage__,
     __version__,
     __version_clean__,
+)
+from qgis_deployment_toolbelt.commands.cmd_completion import (
+    HAS_ARGCOMPLETE,
+    parser_completion,
 )
 from qgis_deployment_toolbelt.commands.cmd_rules_context import (
     parser_rules_context_export,
@@ -191,7 +196,8 @@ def build_parser() -> argparse.ArgumentParser:
     # Main logic
     subcmd_deployment = subparsers.add_parser(
         "deploy",
-        help="QDT's main logic: run the deployment's scenario.",
+        help="QDT's main logic: run the deployment's scenario. It's the default "
+        "subcommand. So `qdt deploy [...]` is equivalent to `qdt [...]`.",
         formatter_class=main_parser.formatter_class,
     )
     add_common_arguments(subcmd_deployment)
@@ -217,6 +223,17 @@ def build_parser() -> argparse.ArgumentParser:
     add_common_arguments(subcmd_upgrade)
     parser_upgrade(subcmd_upgrade)
 
+    # Shell completion
+    subcmd_completion = subparsers.add_parser(
+        "completion",
+        help=(
+            "Print shell completion script to stdout. "
+            "Requires argcomplete: `pip install 'qgis-deployment-toolbelt[completion]'`."
+        ),
+        formatter_class=main_parser.formatter_class,
+    )
+    parser_completion(subcmd_completion)
+
     return main_parser
 
 
@@ -232,6 +249,12 @@ def main(in_args: list[str] | None = None):
         in_args (List[str], optional): list of command-line arguments. Defaults to None.
     """
     main_parser = build_parser()
+
+    # autocompletion
+    if HAS_ARGCOMPLETE:
+        import argcomplete
+
+        argcomplete.autocomplete(main_parser)
 
     # -- PARSE ARGS --
     set_default_subparser(parser_to_update=main_parser, default_subparser_name="deploy")

--- a/qgis_deployment_toolbelt/commands/cmd_completion.py
+++ b/qgis_deployment_toolbelt/commands/cmd_completion.py
@@ -74,7 +74,7 @@ fish:
         >~/.config/fish/completions/{__executable_name__}.fish
 
 powershell:
-    Register-PythonArgcomplete {__executable_name__} | Out-String | Invoke-Expression
+    register-python-argcomplete --shell powershell {__executable_name__} | Out-String | Invoke-Expression
 """
 ).strip()
 

--- a/qgis_deployment_toolbelt/commands/cmd_completion.py
+++ b/qgis_deployment_toolbelt/commands/cmd_completion.py
@@ -1,0 +1,123 @@
+#! python3  # noqa: E265
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sub-command to generate shell completion scripts.
+
+Author: Julien M. (https://github.com/guts)
+"""
+
+
+# ############################################################################
+# ########## IMPORTS #############
+# ################################
+
+# standard library
+import argparse
+import importlib.util
+import logging
+import sys
+from textwrap import dedent
+
+
+# 3rd party
+HAS_ARGCOMPLETE: bool = importlib.util.find_spec("argcomplete") is not None
+
+# package
+from qgis_deployment_toolbelt.__about__ import __executable_name__
+
+
+# ############################################################################
+# ########## GLOBALS #############
+# ################################
+
+logger = logging.getLogger(__name__)
+
+
+COMPLETION_SNIPPETS: str = dedent(
+    f"""
+If you encountered register-python-argcomplete command not found error,
+or if you are using zipapp, run
+
+    pipx install 'gqis-deployment-toolbelt[completion]'
+
+    or if you already installed QDT
+
+    pipx inject qgis-deployment-toolbelt argcomplete
+
+before running any of the following commands.
+
+
+Add the appropriate command to your shell's config file
+so that it is run on startup. You will likely have to restart
+or re-login for the autocompletion to start working.
+
+bash (in '~/.bashrc' or '~/.profile'):
+
+    eval "$(register-python-argcomplete {__executable_name__})"
+
+zsh:
+
+    To activate completions in zsh, first make sure compinit is enabled:
+
+    autoload -U compinit && compinit
+
+    Afterwards you can enable completions for {__executable_name__}:
+
+    eval "$(register-python-argcomplete {__executable_name__})"
+
+tcsh:
+    eval `register-python-argcomplete --shell tcsh {__executable_name__}`
+
+fish:
+    # Not required to be in the config file, only run once
+    register-python-argcomplete --shell fish {__executable_name__} \\
+        >~/.config/fish/completions/{__executable_name__}.fish
+
+powershell:
+    Register-PythonArgcomplete {__executable_name__} | Out-String | Invoke-Expression
+"""
+).strip()
+
+# ############################################################################
+# ########## CLI #################
+# ################################
+
+
+def parser_completion(
+    subparser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Set the argument parser for the completion subcommand.
+
+    Args:
+        subparser (argparse.ArgumentParser): parser to set up
+
+    Returns:
+        argparse.ArgumentParser: parser ready to use
+    """
+
+    subparser.set_defaults(func=run)
+
+    return subparser
+
+
+# ############################################################################
+# ########## MAIN ################
+# ################################
+
+
+def run(args: argparse.Namespace) -> None:
+    """Run the sub command logic.
+
+    Args:
+        args (argparse.Namespace): arguments passed to the subcommand
+    """
+    logger.debug(f"Running {args.command} with {args}")
+
+    if not HAS_ARGCOMPLETE:
+        logger.error(
+            "argcomplete is not installed. "
+            "Run: pip install 'gqis-deployment-toolbelt[completion]'"
+        )
+        sys.exit(1)
+
+    print(COMPLETION_SNIPPETS)  # noqa: T201

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -22,20 +22,6 @@ from qgis_deployment_toolbelt.commands import cmd_completion
 
 
 # #############################################################################
-# ######## Globals #################
-# ##################################
-
-# Distinctive marker in each shell's generated output — executable-name-agnostic
-SHELL_MARKERS = {
-    "bash": '_ARGCOMPLETE_SHELL="bash"',
-    "zsh": "${ZSH_VERSION-}",
-    "fish": "_ARGCOMPLETE_SHELL fish",
-    "tcsh": "python-argcomplete-tcsh",
-    "powershell": "Register-ArgumentCompleter",
-}
-
-
-# #############################################################################
 # ######## Fixtures ################
 # ##################################
 

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,77 @@
+#! python3  # noqa: E265
+
+"""
+Test CLI's completion subcommand.
+
+Author: Julien M. (https://github.com/guts)
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# standard library
+from unittest.mock import patch
+
+# 3rd party
+import pytest
+
+# project
+from qgis_deployment_toolbelt import cli
+from qgis_deployment_toolbelt.commands import cmd_completion
+
+
+# #############################################################################
+# ######## Globals #################
+# ##################################
+
+# Distinctive marker in each shell's generated output — executable-name-agnostic
+SHELL_MARKERS = {
+    "bash": '_ARGCOMPLETE_SHELL="bash"',
+    "zsh": "${ZSH_VERSION-}",
+    "fish": "_ARGCOMPLETE_SHELL fish",
+    "tcsh": "python-argcomplete-tcsh",
+    "powershell": "Register-ArgumentCompleter",
+}
+
+
+# #############################################################################
+# ######## Fixtures ################
+# ##################################
+
+
+@pytest.fixture(scope="session")
+def argcomplete_available():
+    """Skip any test using this fixture when argcomplete is not installed."""
+    pytest.importorskip(
+        "argcomplete",
+        reason="argcomplete is not installed. Install it with: "
+        "pip install 'qgis-deployment-toolbelt[completion]'",
+    )
+
+
+# #############################################################################
+# ######## Tests ###################
+# ##################################
+
+
+def test_cli_completion_without_argcomplete(capsys):
+    """When argcomplete is not available, the command exits with code 1.
+
+    This test always runs, regardless of whether argcomplete is installed.
+    """
+    with patch.object(cmd_completion, "HAS_ARGCOMPLETE", False):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(["completion"])
+
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.parametrize("option", ("-h", "--help"))
+def test_cli_completion_help(capsys, option):
+    """Test completion subcommand help."""
+    with pytest.raises(SystemExit):
+        cli.main(["completion", option])
+
+    _, err = capsys.readouterr()
+    assert err == ""


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Add an extra dependency to enable CLI autocompletion, using argcomplete. Inspired from https://typer.tiangolo.com/tutorial/options-autocompletion/ and https://pipx.pypa.io/stable/how-to/shell-completions/.

It's mainly for tests, dev and training use cases.

[Capture vidéo du 2026-05-28 17-09-38.webm](https://github.com/user-attachments/assets/1cfcac3a-51fc-4d73-9243-750d4c1390ed)


I asked claude.ai if autocompletion could work in frozen mode (built with PyInstaller). Finally I did not find the result relevant so I removed and made the autocompletion not available in frozen mode.

Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
