### PR TITLE
improve(docs): use sphinx-argparse instead of sphinx-argparse-cli

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,9 +41,9 @@ extensions = [
     "sphinx.ext.napoleon",
     # 3rd party
     "myst_parser",
-    "sphinx_argparse_cli",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinxarg.ext",
     "sphinxcontrib.mermaid",
     "sphinxext.opengraph",
     "sphinx_sitemap",
@@ -132,6 +132,11 @@ intersphinx_mapping = {
 
 # -- Extension configuration -------------------------------------------------
 
+# argparse
+sphinxarg_build_commands_index = True
+sphinxarg_commands_index_in_toctree = True
+
+# autodoc
 autodoc_default_options = {
     "special-members": "__init__",
 }

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -2,10 +2,33 @@
 
 Aliases : `qdt`, `qgis-deployment-toolbelt`, `qdeploy-toolbelt`
 
-```{sphinx_argparse_cli}
+## deploy
+
+:::{tip}
+This subcommand is defined as default. So `qdt -s [...]` is equivalent to `qdt deploy -s [...]`
+:::
+
+```{argparse}
   :module: qgis_deployment_toolbelt.cli
-  :func: main
-  :hook:
-  :title: Commands and options
-  :epilog:
+  :func: build_parser
+  :path: deploy
+  :prog: qdt
+```
+
+## export-rules-context
+
+```{argparse}
+  :module: qgis_deployment_toolbelt.cli
+  :func: build_parser
+  :path: export-rules-context
+  :prog: qdt
+```
+
+## upgrade
+
+```{argparse}
+  :module: qgis_deployment_toolbelt.cli
+  :func: build_parser
+  :path: upgrade
+  :prog: qdt
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ doc = [
     "furo>=2024",
     "matplotlib>=3.8.2,<4",
     "myst-parser[linkify]>=2",
-    "sphinx-argparse-cli>=1.19",
+    "sphinx-argparse>=0.5.2,<1",
     "sphinx-autobuild>=2024",
     "sphinx-copybutton<1",
     "sphinx-design>=0.5,<1",

--- a/qgis_deployment_toolbelt/cli.py
+++ b/qgis_deployment_toolbelt/cli.py
@@ -150,14 +150,11 @@ def set_default_subparser(
                 args.insert(0, default_subparser_name)
 
 
-# ############################################################################
-# ########## MAIN ################
-# ################################
-def main(in_args: list[str] | None = None):
-    """Main CLI entrypoint.
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the CLI argument parser.
 
-    Args:
-        in_args (List[str], optional): list of command-line arguments. Defaults to None.
+    Returns:
+        argparse.ArgumentParser: configured top-level parser
     """
     # create the top-level parser
     main_parser = argparse.ArgumentParser(
@@ -219,6 +216,22 @@ def main(in_args: list[str] | None = None):
     )
     add_common_arguments(subcmd_upgrade)
     parser_upgrade(subcmd_upgrade)
+
+    return main_parser
+
+
+# ############################################################################
+# ########## MAIN ################
+# ################################
+
+
+def main(in_args: list[str] | None = None):
+    """Main CLI entrypoint.
+
+    Args:
+        in_args (List[str], optional): list of command-line arguments. Defaults to None.
+    """
+    main_parser = build_parser()
 
     # -- PARSE ARGS --
     set_default_subparser(parser_to_update=main_parser, default_subparser_name="deploy")


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Same work has been done in https://github.com/opengisch/qgis-plugin-ci/pull/402

Funded by Oslandia


<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
