### PR TITLE
release: bump version to 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ Unreleased
 
 -->
 
+## 0.43.0 - 2026-05-29
+
+### Security 🔒
+
+* chore(deps): bump dulwich minimal version to 1.2.5 to cover a security issue in previous versions by @Guts in <https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/841>
+
+### Features and enhancements 🎉
+
+* feature(shortcuts): pick icon format supported by current os by @Guts in <https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/838>
+* feature(autocompletion): enable CLI autocompletion using argcomplete by @Guts in <https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/839>
+
+### Documentation 📖
+
+* improve(docs): use sphinx-argparse instead of sphinx-argparse-cli by @Guts in <https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/840>
+
 ## 0.42.0 - 2026-05-12
 
 ### Bugs fixes 🐛

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,4 +219,4 @@ where = ["."]
 
 [tool.setuptools_scm]
 write_to = "qgis_deployment_toolbelt/_version.py"
-fallback_version = "0.43.0-dev"
+fallback_version = "0.44.0-dev"


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Releasing 0.43.0 to have a published version shipping the dulwich security fixes: https://github.com/jelmer/dulwich/releases/tag/dulwich-1.2.5

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [ ] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [ ] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
