### PR TITLE
fix(logs): bump pyad to 0.6.4 to get upstream fix of unwanted logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "packaging>=22,<27",
     "pypac>=0.16.3,<1",
     "python-rule-engine>=0.5,<1.1",
-    "python-win-ad==0.6.2 ; sys_platform == 'win32'", # waiting for logging fix. See issue #700
+    "python-win-ad==0.6.4 ; sys_platform == 'win32'",
     "pywin32==311 ; sys_platform == 'win32'",
     "pyyaml>=5.4,<7",
     "requests>=2.32.3,<3",

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -358,5 +358,5 @@ class OSConfiguration:
         else:
             raise ValueError(
                 f"Unsupported operating system specified: {operating_system_codename}. "
-                "Must be one of: {', '.join('darwin', 'linux', 'win32')}"
+                f"Must be one of: {', '.join(['darwin', 'linux', 'win32'])}"
             )

--- a/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_synchronizer.py
@@ -206,12 +206,12 @@ class JobProfilesSynchronizer(GenericJob):
                 )
                 if len(compare_for_info[0]):
                     logger.info(
-                        f"{compare_for_info[0]} of installed plugins are outdated comparing with"
+                        f"{compare_for_info[0]} of installed profiles are outdated comparing with"
                         f" downloaded ones: {','.join([p.name for p in compare_for_info[0]])}."
                     )
                 elif len(compare_for_info[1]):
                     logger.info(
-                        f"{compare_for_info[1]} of installed plugins are outdated comparing with"
+                        f"{compare_for_info[1]} of installed profiles are outdated comparing with"
                         f" downloaded ones: {','.join([p.name for p in compare_for_info[1]])}."
                     )
                 else:


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Fix the unwanted log message occurring on non-domain computers ([for example on CI](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/actions/runs/26626856963/job/78465613787#step:7:12)):

```python
WARN: unable to connect to default domain. Computer is likely not attached to an AD domain.
```

The bug has been fixed upstream: https://github.com/jcarswell/pyad/pull/8.

This PR ships other minor logs fixes.

Funded by Oslandia

<!-- osl:grant-oss-2026 -->

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
