### PR TITLE
feature(plugins): add a JSON manifest to track plugins managed by QDT

### DIFF
--- a/docs/jobs/plugins_synchronizer.md
+++ b/docs/jobs/plugins_synchronizer.md
@@ -61,3 +61,11 @@ Default: `~/.cache/qgis-deployment-toolbelt/plugins`
 1. If version plugin in installed profile is inferior, unzip the download plugin in installed profiles. Upgrade process can be controlled per plugin in `profile.json` using [`upgrade_mode`](../reference/qdt_profile.md#plugin-upgrade-mode):
    - `keep` (default): existing plugin folder is kept, newer version is unpacked on top of it,
    - `delete`: existing plugin folder is deleted before unpack.
+
+### QDT-managed plugins manifest
+
+> Added in version 0.44.0
+
+Every plugin installed or upgraded by this job is recorded in a `.qdt-managed-plugins.json` file, stored directly under the profile's `python/plugins` folder (next to the plugin folders themselves). For each plugin, it keeps its version, its plugin ID (when known), the QDT version that deployed it and the installation date.
+
+This manifest lets QDT keep track of which plugins it actually deployed, as opposed to plugins installed manually by the end-user within the same profile (for example, through QGIS' own Plugin Manager). It's meant to be internally read by QDT and shouldn't be edited manually.

--- a/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
@@ -12,11 +12,14 @@ Author: Julien Moura (https://github.com/guts)
 # ##################################
 
 # Standard library
+import json
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from shutil import ReadError, unpack_archive
 
 # package
+from qgis_deployment_toolbelt.__about__ import __version_clean__
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.plugins.plugin import QgisPlugin
 from qgis_deployment_toolbelt.profiles.qdt_profile import QdtProfile
@@ -65,6 +68,7 @@ class JobPluginsSynchronizer(GenericJob):
             "condition": None,
         },
     }
+    QDT_MANAGED_PLUGINS_MANIFEST_FILENAME: str = ".qdt-managed-plugins.json"
 
     def __init__(self, options: dict) -> None:
         """Instantiate the class.
@@ -100,7 +104,7 @@ class JobPluginsSynchronizer(GenericJob):
         # local vars
         profile_plugins_to_create: list[tuple[QdtProfile, QgisPlugin, Path]] = []
         profile_plugins_to_restore = []
-        profile_plugins_to_upgrade = []
+        profile_plugins_to_upgrade: list[tuple[QdtProfile, QgisPlugin, Path]] = []
 
         # get profiles, downloaded or installed
         qdt_profiles = self.filter_profiles_folder(
@@ -201,8 +205,9 @@ class JobPluginsSynchronizer(GenericJob):
                 f"Every plugins are up to date in the {len(qdt_profiles)} profiles parsed."
             )
         else:
-            self.install_plugin_into_profile(profile_plugins_to_create)
-            self.install_plugin_into_profile(profile_plugins_to_upgrade)
+            self.install_plugin_into_profile(
+                profile_plugins_to_create + profile_plugins_to_upgrade
+            )
 
         logger.debug(f"Job {self.ID} ran successfully.")
 
@@ -216,6 +221,9 @@ class JobPluginsSynchronizer(GenericJob):
             list_plugins_to_profiles (List[Tuple[QdtProfile, QgisPlugin, Path]]): list \
                 of tuples containing the target profile, the plugin object and the ZIP path.
         """
+        # ùanifest to keep track of plugins managed by QDT
+        qdt_managed_plugins_manifests: dict[Path, dict[str, dict[str, str]]] = {}
+
         for profile, plugin, source_path in list_plugins_to_profiles:
             if self.options.get("profile_ref") == "installed":
                 profile_plugins_folder = profile.folder / "python/plugins"
@@ -236,7 +244,8 @@ class JobPluginsSynchronizer(GenericJob):
                 if plugin_installed_folder.is_dir():
                     logger.debug(
                         f"Profile {profile.name} - "
-                        f"Plugin {plugin.name} is already installed. It will be deleted before installing the new version."
+                        f"Plugin {plugin.name} is already installed. It will be deleted "
+                        "before installing the new version."
                     )
                     try:
                         move_files_to_trash_or_delete(
@@ -245,7 +254,8 @@ class JobPluginsSynchronizer(GenericJob):
                     except OSError as err:
                         logger.error(
                             f"Profile {profile.name} - "
-                            f"Plugin {plugin.name} could not be deleted before installing the new version. Trace: {err}"
+                            f"Plugin {plugin.name} could not be deleted before "
+                            f"installing the new version. Trace: {err}"
                         )
                         continue
 
@@ -262,11 +272,84 @@ class JobPluginsSynchronizer(GenericJob):
                 )
                 continue
 
+            # Manifest of profile's plugins managed by QDT
+            manifest_path = (
+                profile_plugins_folder / self.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            )
+            if manifest_path not in qdt_managed_plugins_manifests:
+                qdt_managed_plugins_manifests[manifest_path] = (
+                    self._read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
+                )
+            self._add_plugin_to_manifest(
+                manifest=qdt_managed_plugins_manifests[manifest_path], plugin=plugin
+            )
+
             logger.info(
                 f"Profile {profile.name} - "
                 f"Plugin {plugin.name} {plugin.version} has been unzipped from "
                 f"{source_path} to {profile_plugins_folder}"
             )
+
+        # save manifests
+        for manifest_path, manifest in qdt_managed_plugins_manifests.items():
+            self._write_qdt_managed_plugins_manifest(
+                manifest_path=manifest_path, manifest=manifest
+            )
+
+    # manifest management
+    def _add_plugin_to_manifest(
+        self, manifest: dict[str, dict[str, str]], plugin: QgisPlugin
+    ) -> None:
+        """Add/update a plugin to the QDT profile manifest.
+
+        Args:
+            manifest (dict[str, dict[str, str]]): manifest dict to amend, in place
+            plugin (QgisPlugin): plugin that has just been installed
+        """
+        manifest[plugin.installation_folder_name] = {
+            "installed_at": datetime.now(tz=timezone.utc).isoformat(),
+            "plg_id": f"{plugin.plugin_id}",
+            "plg_version": plugin.version,
+            "qdt_version": f"{__version_clean__}",
+        }
+
+    def _read_qdt_managed_plugins_manifest(
+        self, manifest_path: Path
+    ) -> dict[str, dict[str, str]]:
+        """Read the QDT-managed plugins manifest from disk, if it exists.
+
+        Args:
+            manifest_path (Path): path to the manifest file
+
+        Returns:
+            dict[str, dict[str, str]]: manifest content, or an empty dict if the
+            file doesn't exist or is corrupted
+        """
+        if not manifest_path.is_file():
+            return {}
+
+        try:
+            return json.loads(manifest_path.read_text(encoding="UTF-8"))
+        except json.JSONDecodeError as err:
+            logger.warning(
+                f"QDT managed plugins manifest '{manifest_path}' is corrupted, it "
+                f"will be recreated. Trace: {err}"
+            )
+            return {}
+
+    def _write_qdt_managed_plugins_manifest(
+        self, manifest_path: Path, manifest: dict[str, dict[str, str]]
+    ) -> None:
+        """Write the QDT-managed plugins manifest to file.
+
+        Args:
+            manifest_path (Path): path to the manifest file
+            manifest (dict[str, dict[str, str]]): manifest content to write
+        """
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True), encoding="UTF-8"
+        )
+        logger.debug(f"QDT managed plugins manifest written: {manifest_path}")
 
 
 # #############################################################################

--- a/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
@@ -221,7 +221,7 @@ class JobPluginsSynchronizer(GenericJob):
             list_plugins_to_profiles (List[Tuple[QdtProfile, QgisPlugin, Path]]): list \
                 of tuples containing the target profile, the plugin object and the ZIP path.
         """
-        # ùanifest to keep track of plugins managed by QDT
+        # Manifest to keep track of plugins managed by QDT
         qdt_managed_plugins_manifests: dict[Path, dict[str, dict[str, str]]] = {}
 
         for profile, plugin, source_path in list_plugins_to_profiles:

--- a/qgis_deployment_toolbelt/plugins/plugin.py
+++ b/qgis_deployment_toolbelt/plugins/plugin.py
@@ -65,16 +65,16 @@ class QgisPlugin:
     OFFICIAL_REPOSITORY_XML = "https://plugins.qgis.org/plugins/plugins.xml"
 
     name: str
-    folder_name: str = None
-    location: QgisPluginLocation = "remote"
-    official_repository: bool = None
-    plugin_id: int = None
-    qgis_maximum_version: str = None
-    qgis_minimum_version: str = None
-    repository_url_xml: str = None
-    url: str = None
-    version: str = "latest"
+    folder_name: str | None = None
+    location: QgisPluginLocation = QgisPluginLocation.remote
+    official_repository: bool | None = None
+    plugin_id: int | None = None
+    qgis_maximum_version: str | None = None
+    qgis_minimum_version: str | None = None
+    repository_url_xml: str | None = None
     upgrade_mode: str = "keep"
+    url: str | None = None
+    version: str = "latest"
 
     @classmethod
     def from_dict(cls, input_dict: dict) -> QgisPlugin:

--- a/tests/test_job_plugins_synchronizer.py
+++ b/tests/test_job_plugins_synchronizer.py
@@ -15,10 +15,12 @@
 # ##################################
 
 # Standard library
+import json
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 # package
 from qgis_deployment_toolbelt.jobs.job_plugins_synchronizer import (
@@ -146,6 +148,199 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
             # and the new files should also be present
             self.assertTrue((plugin_folder / "metadata.txt").exists())
             self.assertTrue((plugin_folder / "__init__.py").exists())
+
+    # -- QDT-managed plugins manifest --------------------------------------------
+    def test_read_qdt_managed_plugins_manifest_missing_file_returns_empty(self):
+        """Test that reading a non-existing manifest returns an empty dict."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_manifest_read_missing_"
+        ) as tmp_dir:
+            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+            manifest_path = Path(tmp_dir) / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            self.assertFalse(manifest_path.exists())
+
+            manifest = job._read_qdt_managed_plugins_manifest(
+                manifest_path=manifest_path
+            )
+            self.assertEqual(manifest, {})
+
+    def test_read_qdt_managed_plugins_manifest_corrupted_file_returns_empty(self):
+        """Test that reading a corrupted manifest logs a warning and returns an
+        empty dict instead of raising."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_manifest_read_corrupted_"
+        ) as tmp_dir:
+            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+            manifest_path = Path(tmp_dir) / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            manifest_path.write_text("this is not valid json", encoding="UTF-8")
+
+            manifest = job._read_qdt_managed_plugins_manifest(
+                manifest_path=manifest_path
+            )
+            self.assertEqual(manifest, {})
+
+    def test_read_qdt_managed_plugins_manifest_existing_file(self):
+        """Test that reading an existing valid manifest returns its content."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_manifest_read_existing_"
+        ) as tmp_dir:
+            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+            manifest_path = Path(tmp_dir) / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            manifest_path.write_text(
+                json.dumps({"test_plugin": {"plg_version": "1.0.0"}}),
+                encoding="UTF-8",
+            )
+
+            manifest = job._read_qdt_managed_plugins_manifest(
+                manifest_path=manifest_path
+            )
+            self.assertEqual(manifest["test_plugin"]["plg_version"], "1.0.0")
+
+    def test_add_plugin_to_manifest_creates_entry(self):
+        """Test that a plugin entry is added to an empty manifest dict, in memory."""
+        job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+        plugin = QgisPlugin.from_dict(
+            {
+                "name": "Test Plugin",
+                "folder_name": "test_plugin",
+                "version": "2.0.0",
+                "plugin_id": 42,
+            }
+        )
+
+        manifest: dict = {}
+        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin)
+
+        self.assertIn("test_plugin", manifest)
+        self.assertEqual(manifest["test_plugin"]["plg_version"], "2.0.0")
+        self.assertEqual(manifest["test_plugin"]["plg_id"], "42")
+        self.assertIn("installed_at", manifest["test_plugin"])
+        self.assertIn("qdt_version", manifest["test_plugin"])
+
+    def test_add_plugin_to_manifest_updates_existing_entry_preserving_others(self):
+        """Test that adding a plugin updates its own entry in place while
+        preserving other existing entries in the same manifest dict."""
+        job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+        other_plugin = QgisPlugin.from_dict(
+            {"name": "Other Plugin", "folder_name": "other_plugin", "version": "1.0.0"}
+        )
+        plugin_v1 = QgisPlugin.from_dict(
+            {"name": "Test Plugin", "folder_name": "test_plugin", "version": "1.0.0"}
+        )
+        plugin_v2 = QgisPlugin.from_dict(
+            {"name": "Test Plugin", "folder_name": "test_plugin", "version": "2.0.0"}
+        )
+
+        manifest: dict = {}
+        job._add_plugin_to_manifest(manifest=manifest, plugin=other_plugin)
+        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin_v1)
+        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin_v2)
+
+        self.assertEqual(len(manifest), 2)
+        self.assertEqual(manifest["other_plugin"]["plg_version"], "1.0.0")
+        self.assertEqual(manifest["test_plugin"]["plg_version"], "2.0.0")
+
+    def test_write_qdt_managed_plugins_manifest(self):
+        """Test that the manifest dict is correctly serialized to disk as JSON."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_manifest_write_"
+        ) as tmp_dir:
+            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
+
+            manifest_path = Path(tmp_dir) / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            job._write_qdt_managed_plugins_manifest(
+                manifest_path=manifest_path,
+                manifest={"test_plugin": {"plg_version": "2.0.0"}},
+            )
+
+            self.assertTrue(manifest_path.is_file())
+            written = json.loads(manifest_path.read_text(encoding="UTF-8"))
+            self.assertEqual(written["test_plugin"]["plg_version"], "2.0.0")
+
+    def test_install_plugin_into_profile_writes_manifest(self):
+        """Test that installing a plugin also records it into the QDT managed
+        plugins manifest, with the expected fields."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_install_manifest_"
+        ) as tmp_dir:
+            options = {"action": "create_or_restore"}
+            job = JobPluginsSynchronizer(options=options)
+
+            profile = self._make_profile_in_tmpdir(Path(tmp_dir), "test_manifest")
+            plugins_folder = profile.path_in_qgis / "python/plugins"
+
+            zip_path = Path(tmp_dir) / "test_plugin_manifest.zip"
+            self._create_fake_plugin_zip(zip_path, "test_plugin")
+
+            plugin = QgisPlugin.from_dict(
+                {
+                    "name": "Test Plugin",
+                    "folder_name": "test_plugin",
+                    "version": "2.0.0",
+                    "plugin_id": 42,
+                }
+            )
+
+            job.install_plugin_into_profile([(profile, plugin, zip_path)])
+
+            manifest_path = plugins_folder / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            self.assertTrue(manifest_path.is_file())
+
+            manifest = json.loads(manifest_path.read_text(encoding="UTF-8"))
+            self.assertIn("test_plugin", manifest)
+            self.assertEqual(manifest["test_plugin"]["plg_version"], "2.0.0")
+            self.assertEqual(manifest["test_plugin"]["plg_id"], "42")
+
+    def test_install_plugin_into_profile_writes_manifest_once_for_several_plugins(
+        self,
+    ):
+        """Test that the manifest is read and written only once per profile, no
+        matter how many plugins are installed into it in a single call."""
+        with tempfile.TemporaryDirectory(
+            prefix="QDT_test_plugins_sync_install_manifest_batch_"
+        ) as tmp_dir:
+            options = {"action": "create_or_restore"}
+            job = JobPluginsSynchronizer(options=options)
+
+            profile = self._make_profile_in_tmpdir(Path(tmp_dir), "test_batch")
+            plugins_folder = profile.path_in_qgis / "python/plugins"
+
+            zip_path_one = Path(tmp_dir) / "plugin_one.zip"
+            self._create_fake_plugin_zip(zip_path_one, "plugin_one")
+            zip_path_two = Path(tmp_dir) / "plugin_two.zip"
+            self._create_fake_plugin_zip(zip_path_two, "plugin_two")
+
+            plugin_one = QgisPlugin.from_dict(
+                {"name": "Plugin One", "folder_name": "plugin_one", "version": "1.0.0"}
+            )
+            plugin_two = QgisPlugin.from_dict(
+                {"name": "Plugin Two", "folder_name": "plugin_two", "version": "1.0.0"}
+            )
+
+            with patch.object(
+                job,
+                "_write_qdt_managed_plugins_manifest",
+                wraps=job._write_qdt_managed_plugins_manifest,
+            ) as mock_write:
+                job.install_plugin_into_profile(
+                    [
+                        (profile, plugin_one, zip_path_one),
+                        (profile, plugin_two, zip_path_two),
+                    ]
+                )
+                # a single write for the two plugins installed into the same profile
+                self.assertEqual(mock_write.call_count, 1)
+
+            # both plugins must still be present in the resulting manifest
+            manifest_path = plugins_folder / job.QDT_MANAGED_PLUGINS_MANIFEST_FILENAME
+            manifest = json.loads(manifest_path.read_text(encoding="UTF-8"))
+            self.assertIn("plugin_one", manifest)
+            self.assertIn("plugin_two", manifest)
 
 
 # #############################################################################


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

This PR adds a mechanism to track plugins which are managed by QDT and to distinguish them from those installed elsewhere, particularly by the end user via the extension manager.

It writes some of plugins and QDT metadata in a `.qdt-managed-plugins.json` file, stored directly under the QGIS profile's `python/plugins` folder (next to the plugin folders themselves).

File for the [QDT Viewer Mode profile](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/tree/main/examples/profiles/Viewer%20Mode):

```json
{
  "QuickOSM": {
    "installed_at": "2026-07-27T10:40:15.294415+00:00",
    "plg_id": "579",
    "plg_version": "2.2.3",
    "qdt_version": "0.43.2"
  },
  "SpreadsheetLayers": {
    "installed_at": "2026-07-27T10:40:15.302316+00:00",
    "plg_id": "766",
    "plg_version": "2.1.0",
    "qdt_version": "0.43.2"
  },
  "menu_from_project": {
    "installed_at": "2026-07-27T10:40:15.243540+00:00",
    "plg_id": "43",
    "plg_version": "2.1.0",
    "qdt_version": "0.43.2"
  },
  "qNote": {
    "installed_at": "2026-07-27T10:40:15.244764+00:00",
    "plg_id": "122",
    "plg_version": "2.3",
    "qdt_version": "0.43.2"
  },
  "quick_map_services": {
    "installed_at": "2026-07-27T10:40:15.248299+00:00",
    "plg_id": "666",
    "plg_version": "0.19.33",
    "qdt_version": "0.43.2"
  },
  "redLayer": {
    "installed_at": "2026-07-27T10:40:15.298729+00:00",
    "plg_id": "752",
    "plg_version": "2.2",
    "qdt_version": "0.43.2"
  }
}
```

Thanks @nicogodet for the discussion about the rationale behind the scenes.

I used claude.ai (Sonnet 5) to write tests and also discuss the implementation.

:moneybag: Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
