### PR TITLE
fix(docs): pin sphinx-argparse to <0.6.0 and use Python 3.12 to fix documentation build

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,7 @@
 name: "📚 Documentation"
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 # Allow one concurrent deployment
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ doc = [
     "furo>=2024",
     "matplotlib>=3.8.2,<4",
     "myst-parser[linkify]>=2",
-    "sphinx-argparse>=0.5.2,<1",
+    "sphinx-argparse>=0.5.2,<0.6.0",
     "sphinx-autobuild>=2024",
     "sphinx-copybutton<1",
     "sphinx-design>=0.5,<1",


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

This PR mean to fix the issue with parallel Sphinx build: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/actions/runs/30259236103/job/89954970271

I tried the agent mode to fix this https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/tasks/d4869ee6-3689-4c0d-8589-a852b9abbefd?session_id=18092065-0839-429a-b388-06f90b853fea but the proposed fix missed the real source (sphinx-argparse). So I disable the parallel build waiting for the upstream fix: https://github.com/sphinx-doc/sphinx-argparse/issues/98.

Then @nicogodet asked Claude on his side (https://claude.ai/share/7fd35bc4-4700-4963-8433-b58b2e148887) and I realized that we can just pin the sphinx-argparse dependency until the upstream fix is reviewed, merged and published in a release.

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
