### PR TITLE
feature(settings): make deletion policy configurable through a 'QDT_DELETION_POLICY' environment variable

### DIFF
--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -19,8 +19,9 @@ Some options and arguments can be set with environment variables.
 
 Some others parameters can be set using environment variables.
 
-| Variable name       | Description              | Default value      |
+| Variable name | Description | Default value |
 | :------------------ | :----------------------: | :----------------: |
+| `QDT_DELETION_POLICY` | Define how QDT behaves when it comes to remove existing files on the end-user disk. Valid values: `trash_only`, `trash_or_delete`,  `force_delete`. See [details below](#deletion-policy). | `trash_or_delete` |
 | `QDT_LOCAL_WORK_DIR` | Local folder where QDT download remote resources (profiles, plugins, etc.) | `~/.cache/qgis-deployment-toolbelt/default/` |
 | `QDT_LOGS_DIR` | Folder where QDT writes the log files, which are automatically rotated. | `~/.cache/qgis-deployment-toolbelt/logs/` |
 | `QDT_LOGS_DELAY_FILE_CREATION` | Delay creation of log file to the first added log. | `true` |
@@ -32,8 +33,16 @@ Some others parameters can be set using environment variables.
 | `QDT_RULES_VARIABLES_PREFIX` | List of prefixes of environment variables considered in rules. Only relevant if RULES_ONLY_PREFIXED_VARIABLES is set to `true`. The list is comma-separated. For example: `QDT_,QGIS_,MYPREFIX_`. | `QDT_,QGIS_` |
 | `QDT_QGIS_EXE_PATH` | Path to the QGIS executable to use. Used in shortcuts. | `/usr/bin/qgis` on Linux and MacOS, `%PROGRAMFILES%/QGIS 3.28/bin/qgis-ltr-bin.exe` on Windows. |
 | `QDT_STREAMED_DOWNLOADS` | If set to `false`, the content of remote files is fully downloaded before being written locally. | `true` |
-| `QDT_SSL_USE_SYSTEM_STORES` | By default, a bundle of SSL certificates is used, through [certifi](https://pypi.org/project/certifi/). If this environment variable is set to `true`, QDT tries to uses the system certificates store. Based on [truststore](https://truststore.readthedocs.io/). See also [How to use custom SSL certificates](../guides/howto_use_custom_ssl_certs.md).  | `False` |
+| `QDT_SSL_USE_SYSTEM_STORES` | By default, a bundle of SSL certificates is used, through [certifi](https://pypi.org/project/certifi/). If this environment variable is set to `true`, QDT tries to uses the system certificates store. Based on [truststore](https://truststore.readthedocs.io/). See also [How to use custom SSL certificates](../guides/howto_use_custom_ssl_certs.md). | `False` |
 | `QDT_SSL_VERIFY` | Enables/disables SSL certificate verification. Useful for environments where the proxy is unreliable with HTTPS connections. Boolean: `true` or `false`. | `True` |
+
+#### Deletion policy
+
+Settable through the `QDT_DELETION_POLICY` environment variable.
+
+- `trash_only`: only try the system trash. If it fails, the item is left untouched on disk and a warning is logged.
+- `trash_or_delete` (default, historical QDT behavior): try the trash first, then permanently delete on failure.
+- `force_delete`: skip the trash entirely, always permanently delete.
 
 ----
 
@@ -41,7 +50,7 @@ Some others parameters can be set using environment variables.
 
 Some of the 3rd party environment variable applies to QDT:
 
-| Variable name       | Description            |
+| Variable name | Description |
 | :------------------ | :----------------------: |
-| `REQUESTS_CA_BUNDLE` | Set the path to the bundle of SSL certificates to use for HTTPS requests. See also [How to use custom SSL certificates](../guides/howto_use_custom_ssl_certs.md).  |
+| `REQUESTS_CA_BUNDLE` | Set the path to the bundle of SSL certificates to use for HTTPS requests. See also [How to use custom SSL certificates](../guides/howto_use_custom_ssl_certs.md). |
 | `QGIS_CUSTOM_CONFIG_PATH` | Used to customize the path to the folder where QGIS stores the user's profiles. See [upstream documentation](https://docs.qgis.org/3.34/en/docs/user_manual/introduction/qgis_configuration.html#profiles-path). |

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -41,8 +41,8 @@ Some others parameters can be set using environment variables.
 Settable through the `QDT_DELETION_POLICY` environment variable.
 
 - `trash_only`: only try the system trash. If it fails, the item is left untouched on disk and a warning is logged.
-- `trash_or_delete` (default, historical QDT behavior): try the trash first, then permanently delete on failure.
-- `force_delete`: skip the trash entirely, always permanently delete.
+- `trash_or_delete` (default): try the trash first, then permanently delete on failure.
+- `force_delete` (QDT behavior before version 0.44.0): skip the trash entirely, always permanently delete.
 
 ----
 

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # defaults
-DELETION_POLICY = Literal["force_delete", "trash_only", "trash_or_delete"]
-DEFAULT_DELETION_POLICY: DELETION_POLICY = "trash_or_delete"
+DeletionPolicy = Literal["force_delete", "trash_only", "trash_or_delete"]
+DEFAULT_DELETION_POLICY: DeletionPolicy = "trash_or_delete"
 DEFAULT_QDT_WORKING_FOLDER = Path.home().joinpath(".cache/qgis-deployment-toolbelt")
 
 # files to ignore when copying profiles. TODO: make it configurable?

--- a/qgis_deployment_toolbelt/constants.py
+++ b/qgis_deployment_toolbelt/constants.py
@@ -24,7 +24,7 @@ from os.path import expanduser, expandvars
 from pathlib import Path
 from shutil import ignore_patterns, which
 from sys import platform as opersys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 # package
 from qgis_deployment_toolbelt.utils.check_path import check_path
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # defaults
+DELETION_POLICY = Literal["force_delete", "trash_only", "trash_or_delete"]
+DEFAULT_DELETION_POLICY: DELETION_POLICY = "trash_or_delete"
 DEFAULT_QDT_WORKING_FOLDER = Path.home().joinpath(".cache/qgis-deployment-toolbelt")
 
 # files to ignore when copying profiles. TODO: make it configurable?

--- a/qgis_deployment_toolbelt/utils/trash_or_delete.py
+++ b/qgis_deployment_toolbelt/utils/trash_or_delete.py
@@ -20,7 +20,7 @@ from shutil import rmtree
 from typing import get_args
 
 # 3rd party library
-from send2trash import TrashPermissionError, send2trash
+from send2trash import send2trash
 
 # project
 from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DELETION_POLICY
@@ -125,7 +125,7 @@ def move_files_to_trash_or_delete(
         try:
             send2trash(paths=files_to_trash)
             logger.debug(f"{len(files_to_trash)} files have been moved to the trash.")
-        except (TrashPermissionError, OSError) as err:
+        except OSError as err:
             logger.exception(
                 f"Moving {len(files_to_trash)} files to the trash in a single batch "
                 f"operation failed. Let's try it file per file. Trace: {err}"
@@ -143,7 +143,7 @@ def move_files_to_trash_or_delete(
             try:
                 send2trash(paths=file_to_trash)
                 logger.debug(f"{file_to_trash} has been moved to the trash.")
-            except (TrashPermissionError, OSError) as err:
+            except OSError as err:
                 if policy == "trash_only":
                     logger.warning(
                         f"Unable to move {file_to_trash} to the trash and policy is "

--- a/qgis_deployment_toolbelt/utils/trash_or_delete.py
+++ b/qgis_deployment_toolbelt/utils/trash_or_delete.py
@@ -117,7 +117,7 @@ def move_files_to_trash_or_delete(
                 _permanently_delete(path)
                 logger.debug(f"{path} has been permanently deleted (force_delete).")
             except OSError as err:
-                logger.error(f"Unable to permanently delete {path}. Trace: {err}")
+                logger.exception(f"Unable to permanently delete {path}. Trace: {err}")
         return
 
     # -- trash_only / trash_or_delete: first try a batch trash operation
@@ -126,7 +126,7 @@ def move_files_to_trash_or_delete(
             send2trash(paths=files_to_trash)
             logger.debug(f"{len(files_to_trash)} files have been moved to the trash.")
         except (TrashPermissionError, OSError) as err:
-            logger.error(
+            logger.exception(
                 f"Moving {len(files_to_trash)} files to the trash in a single batch "
                 f"operation failed. Let's try it file per file. Trace: {err}"
             )
@@ -158,7 +158,7 @@ def move_files_to_trash_or_delete(
                     _permanently_delete(file_to_trash)
                     logger.debug(f"Deleting directly {file_to_trash} succeeded.")
                 except OSError as err_delete:
-                    logger.error(
+                    logger.exception(
                         f"An error occurred trying to delete {file_to_trash}. "
                         f"Trace: {err_delete}"
                     )

--- a/qgis_deployment_toolbelt/utils/trash_or_delete.py
+++ b/qgis_deployment_toolbelt/utils/trash_or_delete.py
@@ -23,7 +23,7 @@ from typing import get_args
 from send2trash import send2trash
 
 # project
-from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DELETION_POLICY
+from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DeletionPolicy
 
 
 # #############################################################################
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # ##################################
 
 
-def get_deletion_policy() -> DELETION_POLICY:
+def get_deletion_policy() -> DeletionPolicy:
     """Resolve the deletion policy from the ``QDT_DELETION_POLICY`` environment
     variable, falling back to the default when unset or invalid.
 
@@ -49,11 +49,11 @@ def get_deletion_policy() -> DELETION_POLICY:
     deletion_policy_from_env = (
         getenv("QDT_DELETION_POLICY", DEFAULT_DELETION_POLICY).strip().lower()
     )
-    if deletion_policy_from_env not in get_args(DELETION_POLICY):
+    if deletion_policy_from_env not in get_args(DeletionPolicy):
         logger.warning(
             "Invalid value for 'QDT_DELETION_POLICY' environment variable: "
             f"'{deletion_policy_from_env}'. "
-            f"Valid values are: {', '.join(get_args(DELETION_POLICY))}. "
+            f"Valid values are: {', '.join(get_args(DeletionPolicy))}. "
             f"Falling back to the default: '{DEFAULT_DELETION_POLICY}'."
         )
         deletion_policy_from_env = DEFAULT_DELETION_POLICY
@@ -79,7 +79,7 @@ def _permanently_delete(path: Path) -> None:
 def move_files_to_trash_or_delete(
     files_to_trash: list[Path] | Path,
     delete_file_per_file: bool = False,
-    policy: DELETION_POLICY | None = None,
+    policy: DeletionPolicy | None = None,
 ) -> None:
     """Remove files or folders from disk, according to a deletion policy.
 

--- a/qgis_deployment_toolbelt/utils/trash_or_delete.py
+++ b/qgis_deployment_toolbelt/utils/trash_or_delete.py
@@ -1,7 +1,8 @@
 #! python3  # noqa: E265
 
-"""
-QDT autocleaner.
+"""Util dedicated to manage removal of files and folders on disk using a configurable
+deletion policy: moving them to the system trash, falling back to permanent deletion
+when trashing fails, or skipping the trash entirely.
 
 Author: Julien Moura (https://github.com/guts)
 """
@@ -13,10 +14,16 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
+from os import getenv
 from pathlib import Path
+from shutil import rmtree
+from typing import get_args
 
 # 3rd party library
 from send2trash import TrashPermissionError, send2trash
+
+# project
+from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DELETION_POLICY
 
 
 # #############################################################################
@@ -32,18 +39,60 @@ logger = logging.getLogger(__name__)
 # ##################################
 
 
+def get_deletion_policy() -> DELETION_POLICY:
+    """Resolve the deletion policy from the ``QDT_DELETION_POLICY`` environment
+    variable, falling back to the default when unset or invalid.
+
+    Returns:
+        DELETION_POLICY: resolved deletion policy.
+    """
+    deletion_policy_from_env = (
+        getenv("QDT_DELETION_POLICY", DEFAULT_DELETION_POLICY).strip().lower()
+    )
+    if deletion_policy_from_env not in get_args(DELETION_POLICY):
+        logger.warning(
+            "Invalid value for 'QDT_DELETION_POLICY' environment variable: "
+            f"'{deletion_policy_from_env}'. "
+            f"Valid values are: {', '.join(get_args(DELETION_POLICY))}. "
+            f"Falling back to the default: '{DEFAULT_DELETION_POLICY}'."
+        )
+        deletion_policy_from_env = DEFAULT_DELETION_POLICY
+
+    return deletion_policy_from_env
+
+
+def _permanently_delete(path: Path) -> None:
+    """Permanently delete a file or folder.
+
+    Args:
+        path (Path): path to remove.
+
+    Raises:
+        OSError: if the removal fails.
+    """
+    if path.is_dir() and not path.is_symlink():
+        rmtree(path=path)
+    else:
+        path.unlink(missing_ok=True)
+
+
 def move_files_to_trash_or_delete(
     files_to_trash: list[Path] | Path,
     delete_file_per_file: bool = False,
+    policy: DELETION_POLICY | None = None,
 ) -> None:
-    """Move files to the trash or directly delete them if it's not possible.
+    """Remove files or folders from disk, according to a deletion policy.
 
     Args:
-        files_to_trash (list[Path] | Path): file path or list of file paths to move to
-            the trash
-        delete_file_per_file (bool, optional): If False : it
-            tries a single batch operation; if True : it works file per file.
+        files_to_trash (list[Path] | Path): file/folder path or list of paths
+            to remove.
+        delete_file_per_file (bool, optional): only relevant for the
+            "trash_only" and "trash_or_delete" policies. If False, it tries a
+            single batch trash operation; if True, it works path per path.
             Defaults to False.
+        policy (DELETION_POLICY | None, optional): deletion policy to apply.
+            If None, it's resolved from the ``QDT_DELETION_POLICY``
+            environment variable. Defaults to None.
     """
     # make sure it's a list
     if isinstance(files_to_trash, Path):
@@ -51,18 +100,40 @@ def move_files_to_trash_or_delete(
             files_to_trash,
         ]
 
-    # first try a batch
+    if not len(files_to_trash):
+        logger.debug("Nothing to remove: empty list of paths.")
+        return
+
+    # resolve policy with priority to the explicit argument over env var
+    if policy is None:
+        policy = get_deletion_policy()
+
+    logger.debug(f"Removing {len(files_to_trash)} path(s) using '{policy}' policy.")
+
+    # -- force_delete: bypass the trash entirely --
+    if policy == "force_delete":
+        for path in files_to_trash:
+            try:
+                _permanently_delete(path)
+                logger.debug(f"{path} has been permanently deleted (force_delete).")
+            except OSError as err:
+                logger.error(f"Unable to permanently delete {path}. Trace: {err}")
+        return
+
+    # -- trash_only / trash_or_delete: first try a batch trash operation
     if not delete_file_per_file:
         try:
             send2trash(paths=files_to_trash)
             logger.debug(f"{len(files_to_trash)} files have been moved to the trash.")
-        except Exception as err:
+        except (TrashPermissionError, OSError) as err:
             logger.error(
                 f"Moving {len(files_to_trash)} files to the trash in a single batch "
                 f"operation failed. Let's try it file per file. Trace: {err}"
             )
             move_files_to_trash_or_delete(
-                files_to_trash=files_to_trash, delete_file_per_file=True
+                files_to_trash=files_to_trash,
+                delete_file_per_file=True,
+                policy=policy,
             )
     else:
         logger.debug(
@@ -72,21 +143,22 @@ def move_files_to_trash_or_delete(
             try:
                 send2trash(paths=file_to_trash)
                 logger.debug(f"{file_to_trash} has been moved to the trash.")
-            except TrashPermissionError as err:
+            except (TrashPermissionError, OSError) as err:
+                if policy == "trash_only":
+                    logger.warning(
+                        f"Unable to move {file_to_trash} to the trash and policy is "
+                        f"'{policy}'. It's left untouched. Trace: {err}"
+                    )
+                    continue
                 logger.warning(
-                    f"Unable to move {file_to_trash} to the trash. "
-                    f"Trace: {err}. Let's try to delete it directly."
+                    f"Unable to move {file_to_trash} to the trash. Trace: {err}. "
+                    f"Let's try to delete it directly (policy: '{policy}')."
                 )
                 try:
-                    file_to_trash.unlink(missing_ok=True)
+                    _permanently_delete(file_to_trash)
                     logger.debug(f"Deleting directly {file_to_trash} succeeded.")
-                except Exception as err:
+                except OSError as err_delete:
                     logger.error(
                         f"An error occurred trying to delete {file_to_trash}. "
-                        f"Trace: {err}"
+                        f"Trace: {err_delete}"
                     )
-            except Exception as err:
-                logger.error(
-                    f"An error occurred trying to move {file_to_trash} to trash. "
-                    f"Trace: {err}"
-                )

--- a/tests/dev/dev_literal.py
+++ b/tests/dev/dev_literal.py
@@ -1,0 +1,11 @@
+from typing import Literal, get_args
+
+deletion_pol = Literal["force_delete", "trash_only", "trash_or_delete"]
+
+
+print("trash_only" in get_args(deletion_pol))
+print("zip" in get_args(deletion_pol))
+
+if not "test" in get_args(deletion_pol):
+    print(get_args(deletion_pol))
+

--- a/tests/test_utils_trash_or_delete.py
+++ b/tests/test_utils_trash_or_delete.py
@@ -1,0 +1,256 @@
+#! python3  # noqa: E265
+
+"""
+Usage from the repo root folder:
+
+.. code-block:: bash
+    # for whole tests
+    python -m unittest tests.test_utils_trash_or_delete
+    # for specific test
+    python -m unittest tests.test_utils_trash_or_delete.TestUtilsTrashOrDelete.test_force_delete_folder
+"""
+
+# standard library
+import tempfile
+import unittest
+from os import environ
+from pathlib import Path
+from unittest.mock import patch
+
+# 3rd party library
+from send2trash import TrashPermissionError
+
+# project
+from qgis_deployment_toolbelt.utils.trash_or_delete import (
+    get_deletion_policy,
+    move_files_to_trash_or_delete,
+)
+
+
+# -- Globals
+ENV_VAR_DELETION_POLICY = "QDT_DELETION_POLICY"
+
+# ############################################################################
+# ########## Classes #############
+# ################################
+
+
+class TestUtilsTrashOrDelete(unittest.TestCase):
+    """Test deletion policies of the autocleaner."""
+
+    def setUp(self):
+        """Fixtures prepared before each test."""
+        environ.pop(ENV_VAR_DELETION_POLICY, None)
+
+    def tearDown(self):
+        """Executed after each test."""
+        environ.pop(ENV_VAR_DELETION_POLICY, None)
+
+    # -- policy resolution ----------------------------------------------------
+    def test_policy_from_environment_default(self):
+        """No env var set -> default is 'trash_or_delete'."""
+        self.assertEqual(get_deletion_policy(), "trash_or_delete")
+
+    def test_policy_from_environment_valid(self):
+        """Valid env var value is honored."""
+        environ[ENV_VAR_DELETION_POLICY] = "force_delete"
+        self.assertEqual(get_deletion_policy(), "force_delete")
+
+    def test_policy_from_environment_case_insensitive(self):
+        """Env var value is normalized (case, surrounding spaces)."""
+        environ[ENV_VAR_DELETION_POLICY] = "  Trash_Only  "
+        self.assertEqual(get_deletion_policy(), "trash_only")
+
+    def test_policy_from_environment_invalid_fallback(self):
+        """Invalid env var value falls back to default."""
+        environ[ENV_VAR_DELETION_POLICY] = "not_a_policy"
+        self.assertEqual(get_deletion_policy(), "trash_or_delete")
+
+    # -- force_delete -----------------------------------------------------------
+    def test_force_delete_folder(self):
+        """FORCE_DELETE removes a non-empty folder without going through the trash."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_force_delete_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            folder_to_delete = Path(tmpdirname) / "profile_to_remove"
+            folder_to_delete.mkdir(parents=True, exist_ok=True)
+            (folder_to_delete / "file.txt").write_text(
+                "je ne suis paaaas un artiiiiiiste"
+            )
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash"
+            ) as mocked_send2trash:
+                move_files_to_trash_or_delete(
+                    files_to_trash=folder_to_delete,
+                    policy="force_delete",
+                )
+                mocked_send2trash.assert_not_called()
+
+            self.assertFalse(folder_to_delete.exists())
+
+    def test_force_delete_file(self):
+        """FORCE_DELETE removes a single file without going through the trash."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_force_delete_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            file_to_delete = Path(tmpdirname) / "file_to_remove.txt"
+            file_to_delete.write_text("content")
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash"
+            ) as mocked_send2trash:
+                move_files_to_trash_or_delete(
+                    files_to_trash=file_to_delete,
+                    policy="force_delete",
+                )
+                mocked_send2trash.assert_not_called()
+
+            self.assertFalse(file_to_delete.exists())
+
+    def test_force_delete_error_is_logged_not_raised(self):
+        """An OSError during force_delete is caught and logged, not propagated."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_force_delete_error_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            fake_path = Path(tmpdirname) / "does_not_matter.txt"
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete._permanently_delete",
+                side_effect=OSError("simulated permission error"),
+            ):
+                try:
+                    move_files_to_trash_or_delete(
+                        files_to_trash=fake_path,
+                        policy="force_delete",
+                    )
+                except OSError:
+                    self.fail("OSError should be caught and logged, not raised.")
+
+    # -- trash_only ---------------------------------------------------------
+    def test_trash_only_keeps_file_on_error(self):
+        """TRASH_ONLY leaves the file untouched if trash fails."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_trash_only_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            file_to_keep = Path(tmpdirname) / "leave_me_alone.txt"
+            file_to_keep.write_text("content")
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash",
+                side_effect=TrashPermissionError("simulated trash failure"),
+            ):
+                move_files_to_trash_or_delete(
+                    files_to_trash=file_to_keep,
+                    policy="trash_only",
+                )
+
+            self.assertTrue(file_to_keep.exists())
+
+    def test_trash_only_succeeds(self):
+        """TRASH_ONLY calls send2trash and does not fall back to deletion."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_trash_only_ok_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            file_to_trash = Path(tmpdirname) / "trash_me.txt"
+            file_to_trash.write_text("content")
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash"
+            ) as mocked_send2trash:
+                move_files_to_trash_or_delete(
+                    files_to_trash=file_to_trash,
+                    policy="trash_only",
+                )
+                mocked_send2trash.assert_called_once()
+
+    # -- trash_or_delete (default) -------------------------------------------
+    def test_trash_or_delete_falls_back_on_folder(self):
+        """TRASH_OR_DELETE (default) permanently removes a folder if trash fails.
+
+        This specifically covers a bug in the previous implementation where
+        Path.unlink() was called on a non-empty folder, raising
+        IsADirectoryError which was not caught by the (too narrow)
+        TrashPermissionError handler, silently leaving the folder on disk.
+        """
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_trash_or_delete_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            folder_to_delete = Path(tmpdirname) / "profile_to_remove"
+            folder_to_delete.mkdir(parents=True, exist_ok=True)
+            (folder_to_delete / "file.txt").write_text("content")
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash",
+                side_effect=OSError("simulated no trash support"),
+            ):
+                move_files_to_trash_or_delete(
+                    files_to_trash=folder_to_delete,
+                    delete_file_per_file=True,
+                )
+
+            self.assertFalse(folder_to_delete.exists())
+
+    def test_trash_or_delete_falls_back_on_file(self):
+        """TRASH_OR_DELETE permanently deletes a single file if trash fails."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_trash_or_delete_file_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            file_to_delete = Path(tmpdirname) / "file_to_remove.txt"
+            file_to_delete.write_text("content")
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash",
+                side_effect=TrashPermissionError("simulated trash permission error"),
+            ):
+                move_files_to_trash_or_delete(
+                    files_to_trash=file_to_delete,
+                    delete_file_per_file=True,
+                )
+
+            self.assertFalse(file_to_delete.exists())
+
+    def test_trash_or_delete_batch_then_single_fallback(self):
+        """Batch send2trash failure triggers the file-per-file retry path."""
+        with tempfile.TemporaryDirectory(
+            prefix="qdt_test_trash_or_delete_batch_", ignore_cleanup_errors=True
+        ) as tmpdirname:
+            file_a = Path(tmpdirname) / "a.txt"
+            file_b = Path(tmpdirname) / "b.txt"
+            file_a.write_text("a")
+            file_b.write_text("b")
+
+            call_count = {"n": 0}
+
+            def _side_effect(paths):
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    # first call: batch, must fail to trigger retry
+                    raise OSError("simulated batch trash failure")
+                # subsequent calls: per-file, let them "succeed" (no-op)
+
+            with patch(
+                "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash",
+                side_effect=_side_effect,
+            ):
+                move_files_to_trash_or_delete(files_to_trash=[file_a, file_b])
+
+            # files were "trashed" (mocked), not deleted, since the per-file
+            # calls succeeded (no exception raised on 2nd/3rd calls)
+            self.assertEqual(call_count["n"], 3)
+
+    # -- misc -----------------------------------------------------------------
+    def test_empty_list_is_a_no_op(self):
+        """Passing an empty list does nothing and does not raise."""
+        with patch(
+            "qgis_deployment_toolbelt.utils.trash_or_delete.send2trash"
+        ) as mocked_send2trash:
+            move_files_to_trash_or_delete(files_to_trash=[])
+            mocked_send2trash.assert_not_called()
+
+
+# ############################################################################
+# ####### Stand-alone run ########
+# ################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

This PR follows-up the discussion with @Ducarouge on https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/869#issuecomment-5101759585.

I asked claude.ai to help me completing docstrings and writing tests:

- get a better coverage
- mocking send2trash

Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
