### PR TITLE
enhance(job/plugins-sync): add `deletion_mode` option

### DIFF
--- a/docs/jobs/plugins_synchronizer.md
+++ b/docs/jobs/plugins_synchronizer.md
@@ -30,6 +30,14 @@ Possible_values:
 - `create_or_restore`: add plugins if not present and replace eventual existing one
 - `remove`: remove plugins which are not listed
 
+### deletion_mode
+
+[Deletion policy](../usage/settings.md#deletion-policy) to apply when it comes to removing files from the end-user disk.
+
+Possible_values: see [Deletion policy](../usage/settings.md#deletion-policy) section in configuration page.
+
+Default: `trash_or_delete`
+
 ### profile_ref
 
 Which `profile.json` file to use as reference.

--- a/docs/schemas/scenario/jobs/qplugins-synchronizer.json
+++ b/docs/schemas/scenario/jobs/qplugins-synchronizer.json
@@ -15,6 +15,16 @@
             ],
             "type": "string"
         },
+        "deletion_mode": {
+            "default": "trash_or_delete",
+            "description": "Deletion policy to apply when it comes to removing files from the end-user disk.",
+            "enum": [
+                "force_delete",
+                "trash_only",
+                "trash_or_delete"
+            ],
+            "type": "string"
+        },
         "profile_ref": {
             "default": "installed",
             "description": "Which `profile.json` file to use as reference.",

--- a/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
@@ -17,9 +17,11 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from shutil import ReadError, unpack_archive
+from typing import get_args
 
 # package
 from qgis_deployment_toolbelt.__about__ import __version_clean__
+from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DeletionPolicy
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.plugins.plugin import QgisPlugin
 from qgis_deployment_toolbelt.profiles.qdt_profile import QdtProfile
@@ -51,6 +53,13 @@ class JobPluginsSynchronizer(GenericJob):
             "required": False,
             "default": "create_or_restore",
             "possible_values": ("create", "create_or_restore", "remove"),
+            "condition": "in",
+        },
+        "deletion_mode": {
+            "type": str,
+            "required": False,
+            "default": DEFAULT_DELETION_POLICY,
+            "possible_values": get_args(DeletionPolicy),
             "condition": "in",
         },
         "profile_ref": {
@@ -249,7 +258,8 @@ class JobPluginsSynchronizer(GenericJob):
                     )
                     try:
                         move_files_to_trash_or_delete(
-                            files_to_trash=plugin_installed_folder
+                            files_to_trash=plugin_installed_folder,
+                            policy=self.options.get("deletion_mode"),
                         )
                     except OSError as err:
                         logger.error(

--- a/scenario.qdt.yml
+++ b/scenario.qdt.yml
@@ -54,6 +54,7 @@ steps:
     uses: qplugins-synchronizer
     with:
       action: create_or_restore
+      deletion_mode: "force_delete"
       profile_ref: installed
 
   - name: Create shortcuts for profiles


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Expose the deletion policy introduced in #870 as an option for the job Plugins Synchronizer.

Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
