### PR TITLE
feature(job/profiles-downloader): add deletion_mode option to Profiles Downloader job

### DIFF
--- a/docs/jobs/profiles_downloader.md
+++ b/docs/jobs/profiles_downloader.md
@@ -76,6 +76,14 @@ With repository on [UNC path](https://en.wikipedia.org/wiki/Path_(computing)#Uni
 
 Name of the branch to use when working with a git repository.
 
+### deletion_mode
+
+[Deletion policy](../usage/settings.md#deletion-policy) to apply when it comes to removing files from the end-user disk.
+
+Possible_values: see [Deletion policy](../usage/settings.md#deletion-policy) section in configuration page.
+
+Default: `trash_or_delete`
+
 ### protocol
 
 Set which protocol to use.

--- a/docs/schemas/scenario/jobs/qprofiles-downloader.json
+++ b/docs/schemas/scenario/jobs/qprofiles-downloader.json
@@ -10,6 +10,16 @@
             "description": "Name of the branch to use when working with a git repository.",
             "type": "string"
         },
+        "deletion_mode": {
+            "default": "trash_or_delete",
+            "description": "Deletion policy to apply when it comes to removing files from the end-user disk.",
+            "enum": [
+                "force_delete",
+                "trash_only",
+                "trash_or_delete"
+            ],
+            "type": "string"
+        },
         "protocol": {
             "description": "Set which protocol to use for downloading profiles.",
             "enum": [

--- a/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
+++ b/qgis_deployment_toolbelt/jobs/job_profiles_downloader.py
@@ -13,8 +13,10 @@ Author: Julien Moura (https://github.com/guts)
 
 # Standard library
 import logging
+from typing import get_args
 
 # package
+from qgis_deployment_toolbelt.constants import DEFAULT_DELETION_POLICY, DeletionPolicy
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
 from qgis_deployment_toolbelt.profiles import LocalGitHandler, RemoteGitHandler
 from qgis_deployment_toolbelt.profiles.remote_http_handler import HttpHandler
@@ -46,6 +48,13 @@ class JobProfilesDownloader(GenericJob):
             "default": "master",
             "possible_values": None,
             "condition": None,
+        },
+        "deletion_mode": {
+            "type": str,
+            "required": False,
+            "default": DEFAULT_DELETION_POLICY,
+            "possible_values": get_args(DeletionPolicy),
+            "condition": "in",
         },
         "protocol": {
             "type": str,
@@ -96,6 +105,7 @@ class JobProfilesDownloader(GenericJob):
                 downloader = RemoteGitHandler(
                     source_repository_url=self.options.get("source"),
                     branch_to_use=self.options.get("branch", "master"),
+                    deletion_mode=self.options.get("deletion_mode"),
                 )
             elif self.options.get("source").startswith("file://"):
                 downloader = LocalGitHandler(

--- a/qgis_deployment_toolbelt/profiles/local_git_handler.py
+++ b/qgis_deployment_toolbelt/profiles/local_git_handler.py
@@ -18,13 +18,11 @@ import logging
 from pathlib import Path
 
 # project
+from qgis_deployment_toolbelt.constants import DeletionPolicy
 from qgis_deployment_toolbelt.profiles.profiles_handler_base import (
     RemoteProfilesHandlerBase,
 )
 from qgis_deployment_toolbelt.utils.check_path import check_path, check_var_can_be_path
-
-
-# 3rd party
 
 
 # #############################################################################
@@ -46,6 +44,7 @@ class LocalGitHandler(RemoteProfilesHandlerBase):
         source_repository_path_or_uri: str | Path,
         source_repository_type: str = "git_local",
         branch_to_use: str | None = None,
+        deletion_mode: DeletionPolicy | None = None,
     ) -> None:
         """Constructor.
 
@@ -56,7 +55,9 @@ class LocalGitHandler(RemoteProfilesHandlerBase):
             NotGitRepository: if uri_or_path doesn't point to a valid Git repository
         """
         super().__init__(
-            source_repository_type=source_repository_type, branch_to_use=branch_to_use
+            source_repository_type=source_repository_type,
+            branch_to_use=branch_to_use,
+            deletion_mode=deletion_mode,
         )
 
         # clean up

--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -26,6 +26,7 @@ from dulwich.repo import Repo
 from giturlparse import GitUrlParsed, parse as git_parse, validate as git_validate
 
 # project
+from qgis_deployment_toolbelt.constants import DeletionPolicy
 from qgis_deployment_toolbelt.utils import proxies
 from qgis_deployment_toolbelt.utils.check_path import check_folder_is_empty
 from qgis_deployment_toolbelt.utils.trash_or_delete import move_files_to_trash_or_delete
@@ -72,6 +73,7 @@ class RemoteProfilesHandlerBase:
             "git_local", "git_remote", "http", "local", "remote"
         ],
         branch_to_use: str | None = None,
+        deletion_mode: DeletionPolicy | None = None,
     ) -> None:
         """Object instanciation.
 
@@ -83,6 +85,8 @@ class RemoteProfilesHandlerBase:
         """
         self.DESTINATION_BRANCH_TO_USE = branch_to_use
         self.SOURCE_REPOSITORY_TYPE = source_repository_type
+
+        self.deletion_mode: DeletionPolicy | None = deletion_mode
 
         # set dulwich log level to avoid too much verbosity
         logging.getLogger("dulwich").setLevel(int(getenv("QDT_LOGS_DULWICH_LEVEL", 20)))
@@ -532,13 +536,16 @@ class RemoteProfilesHandlerBase:
                         "Clone fail 1/2. Removing target folder and trying again..."
                     )
                     move_files_to_trash_or_delete(
-                        files_to_trash=to_local_destination_path
+                        files_to_trash=to_local_destination_path,
+                        policy=self.deletion_mode,
                     )
                     return self.clone_or_pull(
                         to_local_destination_path=to_local_destination_path, attempt=2
                     )
                 logger.critical("Clone fail 2/2. Abort.")
-                move_files_to_trash_or_delete(files_to_trash=to_local_destination_path)
+                move_files_to_trash_or_delete(
+                    files_to_trash=to_local_destination_path, policy=self.deletion_mode
+                )
                 raise err
         elif to_local_destination_path.exists() and self.is_valid_git_repository(
             source_repository_path_or_url=to_local_destination_path,
@@ -555,7 +562,9 @@ class RemoteProfilesHandlerBase:
                     f"{self.SOURCE_REPOSITORY_PATH_OR_URL} "
                     f"to {to_local_destination_path.resolve()}. Trace: {error}."
                 )
-                move_files_to_trash_or_delete(files_to_trash=to_local_destination_path)
+                move_files_to_trash_or_delete(
+                    files_to_trash=to_local_destination_path, policy=self.deletion_mode
+                )
                 return self.clone_or_pull(
                     to_local_destination_path=to_local_destination_path
                 )
@@ -569,7 +578,9 @@ class RemoteProfilesHandlerBase:
                     f"repository to {to_local_destination_path.resolve()}. Trace: {error}."
                     "Trying to remove the local folder and cloning again..."
                 )
-                move_files_to_trash_or_delete(files_to_trash=to_local_destination_path)
+                move_files_to_trash_or_delete(
+                    files_to_trash=to_local_destination_path, policy=self.deletion_mode
+                )
                 return self.clone_or_pull(
                     to_local_destination_path=to_local_destination_path
                 )

--- a/qgis_deployment_toolbelt/profiles/remote_git_handler.py
+++ b/qgis_deployment_toolbelt/profiles/remote_git_handler.py
@@ -17,6 +17,7 @@ Inspired from: QGIS Resource Sharing
 import logging
 
 # project
+from qgis_deployment_toolbelt.constants import DeletionPolicy
 from qgis_deployment_toolbelt.profiles.profiles_handler_base import (
     RemoteProfilesHandlerBase,
 )
@@ -41,6 +42,7 @@ class RemoteGitHandler(RemoteProfilesHandlerBase):
         source_repository_url: str,
         source_repository_type: str = "git_remote",
         branch_to_use: str | None = None,
+        deletion_mode: DeletionPolicy | None = None,
     ) -> None:
         """Constructor.
 
@@ -49,7 +51,9 @@ class RemoteGitHandler(RemoteProfilesHandlerBase):
 
         """
         super().__init__(
-            source_repository_type=source_repository_type, branch_to_use=branch_to_use
+            source_repository_type=source_repository_type,
+            branch_to_use=branch_to_use,
+            deletion_mode=deletion_mode,
         )
 
         self.SOURCE_REPOSITORY_PATH_OR_URL = source_repository_url

--- a/qgis_deployment_toolbelt/profiles/remote_http_handler.py
+++ b/qgis_deployment_toolbelt/profiles/remote_http_handler.py
@@ -22,6 +22,7 @@ import requests
 
 # project
 from qgis_deployment_toolbelt.__about__ import __title_clean__, __version__
+from qgis_deployment_toolbelt.constants import DeletionPolicy
 from qgis_deployment_toolbelt.profiles.profiles_handler_base import (
     RemoteProfilesHandlerBase,
 )
@@ -63,6 +64,7 @@ class HttpHandler(RemoteProfilesHandlerBase):
         self,
         source_repository_path_or_uri: str,
         source_repository_type: str = "http",
+        deletion_mode: DeletionPolicy | None = None,
     ) -> None:
         """Constructor.
 
@@ -72,7 +74,9 @@ class HttpHandler(RemoteProfilesHandlerBase):
         self.SOURCE_REPOSITORY_PATH_OR_URL = url_ensure_trailing_slash(
             source_repository_path_or_uri
         )
-        super().__init__(source_repository_type=source_repository_type)
+        super().__init__(
+            source_repository_type=source_repository_type, deletion_mode=deletion_mode
+        )
 
     def download(self, destination_local_path: Path):
         """Generic wrapper around the specific logic of this handler.

--- a/scenario.qdt.yml
+++ b/scenario.qdt.yml
@@ -38,6 +38,7 @@ steps:
       source: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli.git
       protocol: git_remote
       branch: main
+      deletion_mode: "trash_or_delete"
 
   - name: Synchronize downloaded profiles with installed ones
     uses: qprofiles-synchronizer


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Expose the deletion policy introduced in #870 as an option for the job Profiles Downloader.

Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
