### PR TITLE
improve(docs): enable GitHub (and GitLab) alert syntax for admonitions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,6 +161,7 @@ mermaid_version = "11.6.0"
 
 # MyST Parser
 myst_enable_extensions = [
+    "alert",
     "colon_fence",
     "deflist",
     "html_admonition",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = ["ruff>=0.13.1", "pre-commit>=4,<5"]
 doc = [
     "furo>=2024",
     "matplotlib>=3.8.2,<4",
-    "myst-parser[linkify]>=2",
+    "myst-parser[linkify]>=5.1.0",
     "sphinx-argparse>=0.5.2,<0.6.0",
     "sphinx-autobuild>=2024",
     "sphinx-copybutton<1",


### PR DESCRIPTION


<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

This way, the admonition/alert is rendered similarly both on GitHub and published HTML doc.

See: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-alerts

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
