### PR TITLE
refactoring(plugins): move code related to manifest of managed plugins to a dedicated module

### DIFF
--- a/qgis_deployment_toolbelt/jobs/job_cleanup_manager.py
+++ b/qgis_deployment_toolbelt/jobs/job_cleanup_manager.py
@@ -11,7 +11,6 @@ Author: Julien Moura (https://github.com/guts)
 # ##################################
 
 # Standard library
-import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,6 +24,7 @@ from qgis_deployment_toolbelt.constants import (
     DeletionPolicy,
 )
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.plugins.manifest import _read_qdt_managed_plugins_manifest
 from qgis_deployment_toolbelt.utils.trash_or_delete import move_files_to_trash_or_delete
 
 
@@ -214,7 +214,7 @@ class JobCleanupManager(GenericJob):
             manifest_path = profile_plugins_folder.joinpath(
                 MANAGED_PLUGINS_MANIFEST_FILENAME
             )
-            managed_plugins = self._read_qdt_managed_plugins_manifest(manifest_path)
+            managed_plugins = _read_qdt_managed_plugins_manifest(manifest_path)
             if not managed_plugins:
                 logger.debug(
                     f"No plugins managed by QDT in profile '{profile.name}' "
@@ -228,32 +228,6 @@ class JobCleanupManager(GenericJob):
                     continue
 
                 self.report.removed.append(plugin_path)
-
-    @staticmethod
-    def _read_qdt_managed_plugins_manifest(manifest_path: Path) -> dict[str, dict]:
-        """Read a QDT managed plugins manifest and return its content.
-
-        Args:
-            manifest_path (Path): profile manifest path
-
-        Returns:
-            dict[str, dict]: parsed manifest content, or an empty mapping
-        """
-        if not manifest_path.is_file():
-            return {}
-
-        try:
-            with manifest_path.open(mode="r", encoding="UTF-8") as in_manifest:
-                manifest = json.load(in_manifest)
-                if isinstance(manifest, dict):
-                    return manifest
-        except Exception as err:
-            logger.warning(
-                f"Unable to parse QDT managed plugins manifest {manifest_path}. "
-                f"Skipping it. Trace: {err}"
-            )
-
-        return {}
 
     def _remove_paths(self) -> None:
         """Remove files and folders listed in the ``self.report.removed``."""

--- a/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
+++ b/qgis_deployment_toolbelt/jobs/job_plugins_synchronizer.py
@@ -12,21 +12,23 @@ Author: Julien Moura (https://github.com/guts)
 # ##################################
 
 # Standard library
-import json
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 from shutil import ReadError, unpack_archive
 from typing import get_args
 
 # package
-from qgis_deployment_toolbelt.__about__ import __version_clean__
 from qgis_deployment_toolbelt.constants import (
     DEFAULT_DELETION_POLICY,
     MANAGED_PLUGINS_MANIFEST_FILENAME,
     DeletionPolicy,
 )
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.plugins.manifest import (
+    _add_plugin_to_manifest,
+    _read_qdt_managed_plugins_manifest,
+    _write_qdt_managed_plugins_manifest,
+)
 from qgis_deployment_toolbelt.plugins.plugin import QgisPlugin
 from qgis_deployment_toolbelt.profiles.qdt_profile import QdtProfile
 from qgis_deployment_toolbelt.utils.trash_or_delete import move_files_to_trash_or_delete
@@ -289,9 +291,9 @@ class JobPluginsSynchronizer(GenericJob):
             manifest_path = profile_plugins_folder / MANAGED_PLUGINS_MANIFEST_FILENAME
             if manifest_path not in qdt_managed_plugins_manifests:
                 qdt_managed_plugins_manifests[manifest_path] = (
-                    self._read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
+                    _read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
                 )
-            self._add_plugin_to_manifest(
+            _add_plugin_to_manifest(
                 manifest=qdt_managed_plugins_manifests[manifest_path], plugin=plugin
             )
 
@@ -303,64 +305,9 @@ class JobPluginsSynchronizer(GenericJob):
 
         # save manifests
         for manifest_path, manifest in qdt_managed_plugins_manifests.items():
-            self._write_qdt_managed_plugins_manifest(
+            _write_qdt_managed_plugins_manifest(
                 manifest_path=manifest_path, manifest=manifest
             )
-
-    # manifest management
-    def _add_plugin_to_manifest(
-        self, manifest: dict[str, dict[str, str]], plugin: QgisPlugin
-    ) -> None:
-        """Add/update a plugin to the QDT profile manifest.
-
-        Args:
-            manifest (dict[str, dict[str, str]]): manifest dict to amend, in place
-            plugin (QgisPlugin): plugin that has just been installed
-        """
-        manifest[plugin.installation_folder_name] = {
-            "installed_at": datetime.now(tz=timezone.utc).isoformat(),
-            "plg_id": f"{plugin.plugin_id}",
-            "plg_version": plugin.version,
-            "qdt_version": f"{__version_clean__}",
-        }
-
-    def _read_qdt_managed_plugins_manifest(
-        self, manifest_path: Path
-    ) -> dict[str, dict[str, str]]:
-        """Read the QDT-managed plugins manifest from disk, if it exists.
-
-        Args:
-            manifest_path (Path): path to the manifest file
-
-        Returns:
-            dict[str, dict[str, str]]: manifest content, or an empty dict if the
-            file doesn't exist or is corrupted
-        """
-        if not manifest_path.is_file():
-            return {}
-
-        try:
-            return json.loads(manifest_path.read_text(encoding="UTF-8"))
-        except json.JSONDecodeError as err:
-            logger.warning(
-                f"QDT managed plugins manifest '{manifest_path}' is corrupted, it "
-                f"will be recreated. Trace: {err}"
-            )
-            return {}
-
-    def _write_qdt_managed_plugins_manifest(
-        self, manifest_path: Path, manifest: dict[str, dict[str, str]]
-    ) -> None:
-        """Write the QDT-managed plugins manifest to file.
-
-        Args:
-            manifest_path (Path): path to the manifest file
-            manifest (dict[str, dict[str, str]]): manifest content to write
-        """
-        manifest_path.write_text(
-            json.dumps(manifest, indent=2, sort_keys=True), encoding="UTF-8"
-        )
-        logger.debug(f"QDT managed plugins manifest written: {manifest_path}")
 
 
 # #############################################################################

--- a/qgis_deployment_toolbelt/plugins/manifest.py
+++ b/qgis_deployment_toolbelt/plugins/manifest.py
@@ -1,0 +1,92 @@
+#! python3  # noqa: E265
+
+"""
+Synchronize plugins between downloaded and installed profiles.
+
+Author: Julien Moura (https://github.com/guts)
+"""
+
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+# project
+from qgis_deployment_toolbelt.__about__ import __version_clean__
+from qgis_deployment_toolbelt.plugins.plugin import QgisPlugin
+
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+
+# #############################################################################
+# ########## Functions ###############
+# ##################################
+
+
+def _add_plugin_to_manifest(
+    manifest: dict[str, dict[str, str]], plugin: QgisPlugin
+) -> None:
+    """Add/update a plugin to the QDT profile manifest.
+
+    Args:
+        manifest (dict[str, dict[str, str]]): manifest dict to amend, in place
+        plugin (QgisPlugin): plugin that has just been installed
+    """
+    manifest[plugin.installation_folder_name] = {
+        "installed_at": datetime.now(tz=timezone.utc).isoformat(),
+        "plg_id": f"{plugin.plugin_id}",
+        "plg_version": plugin.version,
+        "qdt_version": f"{__version_clean__}",
+    }
+
+
+def _read_qdt_managed_plugins_manifest(
+    manifest_path: Path,
+) -> dict[str, dict[str, str]]:
+    """Read the QDT-managed plugins manifest from disk, if it exists.
+
+    Args:
+        manifest_path (Path): path to the manifest file
+
+    Returns:
+        dict[str, dict[str, str]]: manifest content, or an empty dict if the
+        file doesn't exist or is corrupted
+    """
+    if not manifest_path.is_file():
+        return {}
+
+    try:
+        return json.loads(manifest_path.read_text(encoding="UTF-8"))
+    except json.JSONDecodeError as err:
+        logger.warning(
+            f"QDT managed plugins manifest '{manifest_path}' is corrupted, it "
+            f"will be recreated. Trace: {err}"
+        )
+        return {}
+
+
+def _write_qdt_managed_plugins_manifest(
+    manifest_path: Path, manifest: dict[str, dict[str, str]]
+) -> None:
+    """Write the QDT-managed plugins manifest to file.
+
+    Args:
+        manifest_path (Path): path to the manifest file
+        manifest (dict[str, dict[str, str]]): manifest content to write
+    """
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding="UTF-8"
+    )
+    logger.debug(f"QDT managed plugins manifest written: {manifest_path}")

--- a/tests/test_job_plugins_synchronizer.py
+++ b/tests/test_job_plugins_synchronizer.py
@@ -24,8 +24,14 @@ from unittest.mock import patch
 
 # package
 from qgis_deployment_toolbelt.constants import MANAGED_PLUGINS_MANIFEST_FILENAME
+from qgis_deployment_toolbelt.jobs import job_plugins_synchronizer
 from qgis_deployment_toolbelt.jobs.job_plugins_synchronizer import (
     JobPluginsSynchronizer,
+)
+from qgis_deployment_toolbelt.plugins.manifest import (
+    _add_plugin_to_manifest,
+    _read_qdt_managed_plugins_manifest,
+    _write_qdt_managed_plugins_manifest,
 )
 from qgis_deployment_toolbelt.plugins.plugin import QgisPlugin
 from qgis_deployment_toolbelt.profiles.qdt_profile import QdtProfile
@@ -156,14 +162,10 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         with tempfile.TemporaryDirectory(
             prefix="QDT_test_plugins_sync_manifest_read_missing_"
         ) as tmp_dir:
-            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
-
             manifest_path = Path(tmp_dir) / MANAGED_PLUGINS_MANIFEST_FILENAME
             self.assertFalse(manifest_path.exists())
 
-            manifest = job._read_qdt_managed_plugins_manifest(
-                manifest_path=manifest_path
-            )
+            manifest = _read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
             self.assertEqual(manifest, {})
 
     def test_read_qdt_managed_plugins_manifest_corrupted_file_returns_empty(self):
@@ -172,14 +174,10 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         with tempfile.TemporaryDirectory(
             prefix="QDT_test_plugins_sync_manifest_read_corrupted_"
         ) as tmp_dir:
-            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
-
             manifest_path = Path(tmp_dir) / MANAGED_PLUGINS_MANIFEST_FILENAME
             manifest_path.write_text("this is not valid json", encoding="UTF-8")
 
-            manifest = job._read_qdt_managed_plugins_manifest(
-                manifest_path=manifest_path
-            )
+            manifest = _read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
             self.assertEqual(manifest, {})
 
     def test_read_qdt_managed_plugins_manifest_existing_file(self):
@@ -187,22 +185,17 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         with tempfile.TemporaryDirectory(
             prefix="QDT_test_plugins_sync_manifest_read_existing_"
         ) as tmp_dir:
-            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
-
             manifest_path = Path(tmp_dir) / MANAGED_PLUGINS_MANIFEST_FILENAME
             manifest_path.write_text(
                 json.dumps({"test_plugin": {"plg_version": "1.0.0"}}),
                 encoding="UTF-8",
             )
 
-            manifest = job._read_qdt_managed_plugins_manifest(
-                manifest_path=manifest_path
-            )
+            manifest = _read_qdt_managed_plugins_manifest(manifest_path=manifest_path)
             self.assertEqual(manifest["test_plugin"]["plg_version"], "1.0.0")
 
     def test_add_plugin_to_manifest_creates_entry(self):
         """Test that a plugin entry is added to an empty manifest dict, in memory."""
-        job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
 
         plugin = QgisPlugin.from_dict(
             {
@@ -214,7 +207,7 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         )
 
         manifest: dict = {}
-        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin)
+        _add_plugin_to_manifest(manifest=manifest, plugin=plugin)
 
         self.assertIn("test_plugin", manifest)
         self.assertEqual(manifest["test_plugin"]["plg_version"], "2.0.0")
@@ -225,7 +218,6 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
     def test_add_plugin_to_manifest_updates_existing_entry_preserving_others(self):
         """Test that adding a plugin updates its own entry in place while
         preserving other existing entries in the same manifest dict."""
-        job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
 
         other_plugin = QgisPlugin.from_dict(
             {"name": "Other Plugin", "folder_name": "other_plugin", "version": "1.0.0"}
@@ -238,9 +230,9 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         )
 
         manifest: dict = {}
-        job._add_plugin_to_manifest(manifest=manifest, plugin=other_plugin)
-        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin_v1)
-        job._add_plugin_to_manifest(manifest=manifest, plugin=plugin_v2)
+        _add_plugin_to_manifest(manifest=manifest, plugin=other_plugin)
+        _add_plugin_to_manifest(manifest=manifest, plugin=plugin_v1)
+        _add_plugin_to_manifest(manifest=manifest, plugin=plugin_v2)
 
         self.assertEqual(len(manifest), 2)
         self.assertEqual(manifest["other_plugin"]["plg_version"], "1.0.0")
@@ -251,10 +243,8 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
         with tempfile.TemporaryDirectory(
             prefix="QDT_test_plugins_sync_manifest_write_"
         ) as tmp_dir:
-            job = JobPluginsSynchronizer(options={"action": "create_or_restore"})
-
             manifest_path = Path(tmp_dir) / MANAGED_PLUGINS_MANIFEST_FILENAME
-            job._write_qdt_managed_plugins_manifest(
+            _write_qdt_managed_plugins_manifest(
                 manifest_path=manifest_path,
                 manifest={"test_plugin": {"plg_version": "2.0.0"}},
             )
@@ -324,9 +314,9 @@ class TestJobPluginsSynchronizer(unittest.TestCase):
             )
 
             with patch.object(
-                job,
+                job_plugins_synchronizer,
                 "_write_qdt_managed_plugins_manifest",
-                wraps=job._write_qdt_managed_plugins_manifest,
+                wraps=_write_qdt_managed_plugins_manifest,
             ) as mock_write:
                 job.install_plugin_into_profile(
                     [


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Follows-up https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/875#issuecomment-5131701760

Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
